### PR TITLE
feat(config): control click handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,20 @@
     "configuration": {
       "title": "%config.title%",
       "properties": {
+        "workspaceSidebar.actions": {
+          "default": "Current Window",
+          "description": "%config.workspaceActions.description%",
+          "enum": [
+            "Current Window",
+            "New Window"
+          ],
+          "enumDescriptions": [
+            "%config.workspaceActions.cur-window%",
+            "%config.workspaceActions.new-window%"
+          ],
+          "scope": "application",
+          "type": "string"
+        },
         "workspaceSidebar.depth": {
           "default": 0,
           "description": "%config.workspaceFolderDepth.description%",
@@ -63,6 +77,14 @@
           "description": "%config.workspaceFolder.description%",
           "scope": "application",
           "type": "string"
+        },
+        "workspaceSidebar.searchMinimum": {
+          "default": 15,
+          "description": "%config.workspaceSearchMinimum.description%",
+          "maximum": 100,
+          "minimum": 0,
+          "scope": "application",
+          "type": "number"
         },
         "workspaceSidebar.showPaths": {
           "default": "As needed",
@@ -79,14 +101,6 @@
           ],
           "scope": "application",
           "type": "string"
-        },
-        "workspaceSidebar.searchMinimum": {
-          "default": 15,
-          "description": "%config.workspaceSearchMinimum.description%",
-          "maximum": 100,
-          "minimum": 0,
-          "scope": "application",
-          "type": "number"
         }
       }
     },

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -1,5 +1,8 @@
 {
   "config.title": "Workspace Sidebar",
+  "config.workspaceActions.cur-window": "Aktuelles Fenster, Iconklicks werden in einem neuen Fenster geöffnet.",
+  "config.workspaceActions.description": "Welche Aktion sollte beim Anklickung auf eine Arbeitsbereich ausgeführt?",
+  "config.workspaceActions.new-window": "Neues Fenster, Iconklicks werden im aktuellen Fenster geöffnet.",
   "config.workspaceFolder.description": "Der Ordnerpfad, in dem nach Arbeitsbereiche gesucht werden soll. Falls leer, wird Ihren Home-Ordner benutzt. '~' wird auch unter Windows durch Ihren Home-Ordner ersetzt.",
   "config.workspaceFolderDepth.description": "In welcher Tiefe von Unterordnern sollte auch gesucht werden. Rang: 0-5",
   "config.workspaceSearchMinimum.description": "Die Mindestanzahl von Arbeitsbereiche, die für die Anzeige der Suchfeld erforderlich sind. Bei 0 wird das Suchfeld immer anzeigt. Rang: 0-100",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,8 @@
 {
   "config.title": "Workspace Sidebar",
+  "config.workspaceActions.cur-window": "Current window, icon clicks will open in a new window.",
+  "config.workspaceActions.description": "What action should be taken when clicking on a workspace in the sidebar?",
+  "config.workspaceActions.new-window": "New window, icon clicks will open in the current window.",
   "config.workspaceFolder.description": "The folder to look in for workspace files - leave blank to default to your home folder. '~' will be replaced with your home folder even on windows.",
   "config.workspaceFolderDepth.description": "What depth of subfolders should also be looked in. Range: 0-5",
   "config.workspaceSearchMinimum.description": "The minimum number of workspace files required for the search box to be displayed. 0 will always show the search box. Range: 0-100",

--- a/resources/js/webview-workspace.js
+++ b/resources/js/webview-workspace.js
@@ -22,12 +22,12 @@
 
   const handleIconClick = (event) => {
     event.stopPropagation();
-    sendMessage('OPEN_NEW_WINDOW', event.currentTarget.dataset.file);
+    sendMessage('ICON_CLICK', event.currentTarget.dataset.file);
   };
 
   const handleElementClick = (event) => {
     event.stopPropagation();
-    sendMessage('OPEN_CUR_WINDOW', event.currentTarget.dataset.file);
+    sendMessage('MAIN_CLICK', event.currentTarget.dataset.file);
   };
 
   const handleViewLInkClick = (event) => {

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -2,6 +2,11 @@ export const CONFIG_DEPTH = 0;
 export const CONFIG_FOLDER = '';
 export const CONFIG_SEARCH_MINIMUM = 15;
 
+export enum ConfigActions {
+  CURRENT_WINDOW = 'Current Window',
+  NEW_WINDOW = 'New Window',
+}
+
 export enum ConfigShowPaths {
   ALWAYS = 'Always',
   AS_NEEEDED = 'As needed',

--- a/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
@@ -19,8 +19,8 @@ export type WorkspaceErrors = '' | 'FETCH';
 
 export enum WorkspacePmActions {
   FOCUS_SEARCH = 'FOCUS_SEARCH',
-  OPEN_CUR_WINDOW = 'OPEN_CUR_WINDOW',
-  OPEN_NEW_WINDOW = 'OPEN_NEW_WINDOW',
+  ICON_CLICK = 'ICON_CLICK',
+  MAIN_CLICK = 'MAIN_CLICK',
   SEARCH = 'SEARCH',
   SHOW_SETTINGS = 'SHOW_SETTINGS',
 }

--- a/src/webviews/Workspace/WorkspaceViewProvider.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.ts
@@ -5,6 +5,7 @@ import { SortIds } from '../../commands/registerCommands';
 import {
   CMD_OPEN_CUR_WIN,
   CMD_OPEN_NEW_WIN,
+  ConfigActions,
   EXT_LOADED,
   EXT_SORT,
   EXT_WEBVIEW_WS,
@@ -156,18 +157,21 @@ export class WorkspaceViewProvider implements vscode.WebviewViewProvider {
     webviewView.webview.onDidReceiveMessage((message: PostMessage<Payload, Actions>) => {
       const { action, payload } = message;
 
-      console.log('### message', action, payload);
-
       switch (action) {
-        case Actions.OPEN_CUR_WINDOW:
+        case Actions.MAIN_CLICK:
+        case Actions.ICON_CLICK:
           if (payload) {
-            executeCommand(CMD_OPEN_CUR_WIN, payload, true);
-          }
-          break;
+            const clickAction: string =
+              vscode.workspace.getConfiguration().get('workspaceSidebar.actions') ??
+              ConfigActions.CURRENT_WINDOW;
+            let cmd =
+              clickAction === ConfigActions.NEW_WINDOW ? CMD_OPEN_NEW_WIN : CMD_OPEN_CUR_WIN;
 
-        case Actions.OPEN_NEW_WINDOW:
-          if (payload) {
-            executeCommand(CMD_OPEN_NEW_WIN, payload, true);
+            if (action === Actions.ICON_CLICK) {
+              cmd = clickAction === ConfigActions.NEW_WINDOW ? CMD_OPEN_CUR_WIN : CMD_OPEN_NEW_WIN;
+            }
+
+            executeCommand(cmd, payload, true);
           }
           break;
 


### PR DESCRIPTION
Fixes #27 

# Config to control what happens when clicking on workspaces/workspace icons

- A new config has been added to decide what happens when clicking on a workspace. The default is to open in the current workspace like before. You can also select new window, the icon clicks will then open in the current window instead.