### PR TITLE
fix(61): exclude folders and hidden file issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,3 @@ This extension is localised, if you want it in your language please send me a tr
 
 - Closes [#89](https://github.com/sketchbuch/vsc-workspace-sidebar/issues/89)
 - Fixed rendering of file icons on windows
-
-## Multiroot Todo
-
-- Paths only if in same folder parent

--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ This extension is localised, if you want it in your language please send me a tr
 
 - Closes [#89](https://github.com/sketchbuch/vsc-workspace-sidebar/issues/89)
 - Fixed rendering of file icons on windows
+
+## Multiroot Todo
+
+- Paths only if in same folder parent

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ File theme icons can also be displayed. For more information see the [File Icon 
 
 ### Folders
 
-| Setting      | Description                                                                                                                     | Default Value                                        | Type                               |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------- |
-| Excluded     | Folders to exclude when searching for workspace files                                                                           | [ "node_modules", "build", "dist", "out", "public" ] | Array of folder names              |
-| Root Folders | The folders to look for workspace files in. **~/** will also be replaced with your home folder in all folders within the array. | []                                                   | Array of absolute paths to folders |
+| Setting      | Description                                                                                                                     | Default Value                                                          | Type                               |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
+| Excluded     | Folders to exclude when searching for workspace files                                                                           | [ "node_modules", "build", "dist", "out", "public", ".cache", ".git" ] | Array of folder names              |
+| Root Folders | The folders to look for workspace files in. **~/** will also be replaced with your home folder in all folders within the array. | []                                                                     | Array of absolute paths to folders |
 
 ### List View
 

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "crypto": "^1.0.1",
     "json5": "^2.2.3",
     "vscode-ext-localisation": "^1.1.0",
-    "vscode-file-theme-processor": "^1.0.3"
+    "vscode-file-theme-processor": "^1.0.4"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^8.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-workspace-sidebar",
   "description": "Adds a sidebar to VSCode that lists Workspaces and lets you open them in the current window or a new window.",
   "displayName": "Workspace Sidebar",
-  "version": "2.0.0-beta-2",
+  "version": "2.0.0-beta-3",
   "activationEvents": [
     "onStartupFinished"
   ],

--- a/package.json
+++ b/package.json
@@ -127,7 +127,9 @@
               "build",
               "dist",
               "out",
-              "public"
+              "public",
+              ".cache",
+              ".git"
             ],
             "description": "%config.folders.excluded.description%",
             "scope": "application",

--- a/resources/css/webview-workspace.css
+++ b/resources/css/webview-workspace.css
@@ -6,6 +6,8 @@
 
 :root {
   --ext-workspace-sidebar__search-offset: 32px;
+  --ext-workspace-sidebar__padding-v: 0.3rem;
+  --ext-workspace-sidebar__padding-h: 20px;
 }
 
 body {

--- a/resources/css/workspace/snippets/folder.css
+++ b/resources/css/workspace/snippets/folder.css
@@ -8,13 +8,13 @@
 
 .list__folder-title {
   margin: 0.7rem 0;
-  padding: 0 20px;
+  padding: 0 var(--ext-workspace-sidebar__padding-h);
   padding-top: 0.5rem;
 }
 
 .list__folder-controls {
   padding-bottom: 0.7rem;
-  padding-top: 0.3rem;
+  padding-top: var(--ext-workspace-sidebar__padding-v);
   text-align: center;
 }
 
@@ -35,7 +35,7 @@
 }
 
 .list__folder-divider {
-  padding: 0 20px;
+  padding: 0 var(--ext-workspace-sidebar__padding-h);
 }
 
 .list__folder-vscodedivider {

--- a/resources/css/workspace/snippets/hoverNotification.css
+++ b/resources/css/workspace/snippets/hoverNotification.css
@@ -5,7 +5,7 @@
   box-shadow: rgba(0, 0, 0, 0.16) 0px 0px 8px 2px;
   box-sizing: border-box;
   color: var(--vscode-notifications-foreground);
-  left: 20px;
+  left: var(--ext-workspace-sidebar__padding-h);
   outline-color: var(--vscode-contrastBorder);
   padding: 10px 5px;
   position: fixed;

--- a/resources/css/workspace/snippets/list.css
+++ b/resources/css/workspace/snippets/list.css
@@ -22,7 +22,7 @@
 }
 
 .list--empty {
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
 }
 
 .list__styled-item {
@@ -41,7 +41,7 @@
   font-size: var(--vscode-font-size);
   margin: 0;
   min-width: 0;
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
   position: relative;
   text-decoration: none;
   touch-action: none;
@@ -60,7 +60,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding-left: 20px;
+  padding-left: var(--ext-workspace-sidebar__padding-h);
   position: relative;
   text-decoration: none;
   touch-action: none;
@@ -197,6 +197,6 @@
 .rootfolder__message {
   list-style: none;
   margin: 0;
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
   padding-left: 40px;
 }

--- a/resources/css/workspace/snippets/search.css
+++ b/resources/css/workspace/snippets/search.css
@@ -7,7 +7,7 @@
   height: var(--ext-workspace-sidebar__search-offset);
   justify-content: flex-start;
   left: 0;
-  padding: 0 20px;
+  padding: 0 var(--ext-workspace-sidebar__padding-h);
   position: fixed;
   top: 0;
   width: 100%;
@@ -34,13 +34,13 @@
 
 .list__searchedout {
   color: var(--vscode-foreground);
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
   padding-top: var(--ext-workspace-sidebar__search-offset);
 }
 
 .list__searchedout p {
   margin: 0;
-  padding: 0.3rem 0;
+  padding: var(--ext-workspace-sidebar__padding-v) 0;
 }
 
 .searchBox__options-section {

--- a/resources/css/workspace/views/error.css
+++ b/resources/css/workspace/views/error.css
@@ -1,3 +1,3 @@
 .error {
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
 }

--- a/resources/css/workspace/views/invalid.css
+++ b/resources/css/workspace/views/invalid.css
@@ -1,3 +1,3 @@
 .invalid {
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
 }

--- a/resources/css/workspace/views/loading.css
+++ b/resources/css/workspace/views/loading.css
@@ -1,3 +1,3 @@
 .loading {
-  padding: 0.3rem 20px;
+  padding: var(--ext-workspace-sidebar__padding-v) var(--ext-workspace-sidebar__padding-h);
 }

--- a/src/test/mocks/mockState.ts
+++ b/src/test/mocks/mockState.ts
@@ -80,7 +80,7 @@ export const getMockRootFolders = (
       convertedFiles,
       files,
       fileTree,
-      folderName: getLastPathSegment(folderPath),
+      folderName: getLastPathSegment(folderPath) || folderPath,
       folderPath,
       folderPathShort: folderPath.replace(OS_HOMEFOLDER, `~`),
       result,

--- a/src/utils/fs/collectFilesFromFolder.ts
+++ b/src/utils/fs/collectFilesFromFolder.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import { getExcludedFoldersConfig } from '../../config/folders'
 import { WorkspaceFiles } from '../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { getFilenamesOfType } from './getFilenamesOfType'
+import { getLastPathSegment } from './getLastPathSegment'
 import { isHiddenFile } from './isHiddenFile'
 
 export const collectFilesFromFolder = async (
@@ -11,25 +12,21 @@ export const collectFilesFromFolder = async (
   curDepth: number
 ): Promise<WorkspaceFiles> => {
   const excludedFoldersConfig = getExcludedFoldersConfig()
+  const lastFolder = getLastPathSegment(folder)
 
-  if (curDepth <= maxDepth) {
+  if (curDepth <= maxDepth && !excludedFoldersConfig.includes(lastFolder)) {
     try {
-      const filenames = await fs.promises.readdir(folder) /* .then((files) => {
+      const filenames = await fs.promises.readdir(folder).then((files) => {
         return files.reduce((allFiles: string[], curFile) => {
-          if (isHiddenFile(curFile)) {
-            console.log('### hidden', curFile)
-          }
-          if ( !isHiddenFile(curFile) &&  !excludedFoldersConfig.includes(curFile)) {
+          if (!excludedFoldersConfig.includes(curFile)) {
             return [...allFiles, curFile]
           }
 
           return allFiles
         }, [])
-      }) */
+      })
 
-      const folders = getFilenamesOfType('folders', filenames, folder, fileType).filter(
-        (file) => !excludedFoldersConfig.includes(file)
-      )
+      const folders = getFilenamesOfType('folders', filenames, folder, fileType)
       let files = getFilenamesOfType('files', filenames, folder, fileType).filter(
         (file) => !isHiddenFile(file)
       )

--- a/src/utils/fs/collectFilesFromFolder.ts
+++ b/src/utils/fs/collectFilesFromFolder.ts
@@ -14,18 +14,25 @@ export const collectFilesFromFolder = async (
 
   if (curDepth <= maxDepth) {
     try {
-      const filenames = await fs.promises.readdir(folder).then((files) => {
+      const filenames = await fs.promises.readdir(folder) /* .then((files) => {
         return files.reduce((allFiles: string[], curFile) => {
-          if (!isHiddenFile(curFile) && !excludedFoldersConfig.includes(curFile)) {
+          if (isHiddenFile(curFile)) {
+            console.log('### hidden', curFile)
+          }
+          if ( !isHiddenFile(curFile) &&  !excludedFoldersConfig.includes(curFile)) {
             return [...allFiles, curFile]
           }
 
           return allFiles
         }, [])
-      })
+      }) */
 
-      const folders = getFilenamesOfType('folders', filenames, folder, fileType)
-      let files = getFilenamesOfType('files', filenames, folder, fileType)
+      const folders = getFilenamesOfType('folders', filenames, folder, fileType).filter(
+        (file) => !excludedFoldersConfig.includes(file)
+      )
+      let files = getFilenamesOfType('files', filenames, folder, fileType).filter(
+        (file) => !isHiddenFile(file)
+      )
 
       if (folders.length > 0) {
         for (let index = 0; index < folders.length; index++) {

--- a/src/webviews/Workspace/WorkspaceViewProvider.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.ts
@@ -6,6 +6,7 @@ import {
   CssGenerator,
   FileThemeProcessor,
   FileThemeProcessorObserver,
+  FileThemeProcessorState,
 } from 'vscode-file-theme-processor'
 import { getActionsConfig } from '../../config/general'
 import { getSearchCaseInsensitiveConfig, getSearchMatchStartConfig } from '../../config/search'
@@ -276,9 +277,8 @@ export class WorkspaceViewProvider
     }
   }
 
-  public notify() {
-    // Only rerender if resolveWebviewView() has been called
-    if (this._view !== undefined) {
+  public notify(state: FileThemeProcessorState) {
+    if (this._view !== undefined && state === 'ready') {
       this.render()
     }
   }

--- a/src/webviews/Workspace/helpers/getFileTree.ts
+++ b/src/webviews/Workspace/helpers/getFileTree.ts
@@ -39,7 +39,7 @@ export const getFileTree = (configFolder: string, files: Files): FileTree => {
     folderPath: configFolder.replace(`~`, homeDir),
     folderPathSegment: rootFolder,
     isRoot: true,
-    label: rootFolder,
+    label: rootFolder || configFolder,
     sub: [],
   }
 

--- a/src/webviews/Workspace/helpers/getVisibleFiles.ts
+++ b/src/webviews/Workspace/helpers/getVisibleFiles.ts
@@ -1,3 +1,4 @@
+import * as pathLib from 'path'
 import { getCleanLabelsConfig } from '../../../config/general'
 import { getShowPathsConfig } from '../../../config/listview'
 import { getShowTreeConfig } from '../../../config/treeview'
@@ -29,11 +30,13 @@ export const getVisibleFiles = (wsFiles: Files, search: SearchState) => {
   }
 
   if (showPaths === ConfigShowPaths.AS_NEEEDED) {
-    const labels = visibleFiles.map((file) => file.label)
-    const dups = findDuplicates(labels)
+    const checks = visibleFiles.map(({ label, path }) =>
+      showTree ? `${label}-${path.split(pathLib.sep)[0]}` : label
+    )
+    const dups = findDuplicates(checks)
 
-    visibleFiles = visibleFiles.map((file: File) => {
-      if (!dups.includes(file.label)) {
+    visibleFiles = visibleFiles.map((file: File, index: number) => {
+      if (!dups.includes(checks[index])) {
         return { ...file, showPath: false }
       }
 

--- a/src/webviews/Workspace/store/fetch.ts
+++ b/src/webviews/Workspace/store/fetch.ts
@@ -59,7 +59,7 @@ export const fetchFulfilled = (
         convertedFiles,
         files,
         fileTree,
-        folderName: getLastPathSegment(folderPath) || folderPath,
+        folderName: folderName || folderPath,
         folderPath,
         folderPathShort: folderPath.replace(homeDir, `~`),
         result,

--- a/src/webviews/Workspace/store/fetch.ts
+++ b/src/webviews/Workspace/store/fetch.ts
@@ -59,7 +59,7 @@ export const fetchFulfilled = (
         convertedFiles,
         files,
         fileTree,
-        folderName: getLastPathSegment(folderPath),
+        folderName: getLastPathSegment(folderPath) || folderPath,
         folderPath,
         folderPathShort: folderPath.replace(homeDir, `~`),
         result,

--- a/src/webviews/Workspace/store/fetch.ts
+++ b/src/webviews/Workspace/store/fetch.ts
@@ -43,7 +43,7 @@ export const fetchFulfilled = (
     state.view = 'list'
 
     state.rootFolders = action.payload.rootFolders.map(({ files, folderPath, result }) => {
-      const folderName = getLastPathSegment(folderPath)
+      const folderName = getLastPathSegment(folderPath) || folderPath
       const convertedFiles = convertWsFiles(folderPath, files, state.selected)
       const visibleFiles = getVisibleFiles(convertedFiles, state.search)
       const fileTree = showTree ? getFileTree(folderPath, visibleFiles) : null
@@ -59,7 +59,7 @@ export const fetchFulfilled = (
         convertedFiles,
         files,
         fileTree,
-        folderName: folderName || folderPath,
+        folderName: folderName,
         folderPath,
         folderPathShort: folderPath.replace(homeDir, `~`),
         result,

--- a/src/webviews/Workspace/store/list.ts
+++ b/src/webviews/Workspace/store/list.ts
@@ -34,7 +34,7 @@ export const list = (
       convertedFiles,
       files,
       fileTree,
-      folderName: getLastPathSegment(folderPath),
+      folderName: folderName || folderPath,
       folderPath,
       folderPathShort: folderPath.replace(homeDir, `~`),
       result: files.length < 1 ? 'no-workspaces' : 'ok',

--- a/src/webviews/Workspace/store/list.ts
+++ b/src/webviews/Workspace/store/list.ts
@@ -18,7 +18,7 @@ export const list = (
   let visibleFileCount = 0
 
   state.rootFolders = action.payload.map(({ files, folderPath }) => {
-    const folderName = getLastPathSegment(folderPath)
+    const folderName = getLastPathSegment(folderPath) || folderPath
     const convertedFiles = convertWsFiles(folderPath, files, state.selected)
     const visibleFiles = getVisibleFiles(convertedFiles, state.search)
     const fileTree = showTree ? getFileTree(folderPath, visibleFiles) : null
@@ -34,7 +34,7 @@ export const list = (
       convertedFiles,
       files,
       fileTree,
-      folderName: folderName || folderPath,
+      folderName: folderName,
       folderPath,
       folderPathShort: folderPath.replace(homeDir, `~`),
       result: files.length < 1 ? 'no-workspaces' : 'ok',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8208,10 +8208,10 @@ vscode-ext-localisation@^1.1.0:
   dependencies:
     path "^0.12.7"
 
-vscode-file-theme-processor@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/vscode-file-theme-processor/-/vscode-file-theme-processor-1.0.3.tgz#ebbb0af7f5ec2d129e59f1f0b9a095097cc93ae7"
-  integrity sha512-mlscQstqqLGlo1Sbed/N0QaImXyye3qfHKMrXVEoqo4Iq4NyTrUQ7LZxgE9p2UBllfXbmNm9XfWsmdyWoNpXaA==
+vscode-file-theme-processor@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/vscode-file-theme-processor/-/vscode-file-theme-processor-1.0.4.tgz#2f3f5cd38fc39eda9c06c6e167c9ee48eddd51e0"
+  integrity sha512-UaojtWY41uyXaSCENC+IXvCZ6//T/o7Z0hYtFaBFCAZ1Qm2iedtXx6ML3aGjEoqjThI+lYSliWlymA7UPHAR2g==
   dependencies:
     json5 "^2.2.3"
 


### PR DESCRIPTION
Fixes: #61 
Fixes: #100 

# Summary of Changes

- Fixed an issue with excluding folders and hidden files
- Updated css
- Fixed issue with a root folder not having last segments and label display
- Updated tests
- Updated exclude folders default value
- Fixed displaying paths only if the visual parent is the same, rather than just using the label (in tree view)
- Updated file theme processor