### PR TITLE
feat(102): fix invalid messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,5 @@ This extension is localised, if you want it in your language please send me a tr
 
 ## Todo
 
-- Error message if folder is in a hidden folder and hidden folders are excluded or a sub folder is excluded
-- Update translations
-- Remove notDirectory translation
-- Create common template for rootfolder error and invalid view
+- Change depth for each root folder
+-- Update depth info for invalid messages

--- a/README.md
+++ b/README.md
@@ -129,8 +129,7 @@ This extension is localised, if you want it in your language please send me a tr
 
 ## Todo
 
-- Fix tests
 - Investigate why compacting not working for first level ws
 - Add exclude hidden to folder config
-- Test exclude hidden for invalid and folder error
 - Remove hidden check from root folder path, should only apply to sub.
+- Check tests on Windows

--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ This extension is localised, if you want it in your language please send me a tr
 
 - Change depth for each root folder
 -- Update depth info for invalid messages
+- Remove depth from rendervars

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ This extension is localised, if you want it in your language please send me a tr
 
 ## Todo
 
-- Change depth for each root folder
--- Update depth info for invalid messages
-- Remove depth from rendervars
+- Fix tests
+- Investigate why compacting not working for first level ws
+- Add exclude hidden to folder config
+- Test exclude hidden for invalid and folder error
+- Remove hidden check from root folder path, should only apply to sub.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This extension is localised, if you want it in your language please send me a tr
 
 ## Todo
 
-- Why was new folder not triggering a reload?
-- Add option to exclude all hidden folders
-- Remove watcher
+- Error message if folder is in a hidden folder and hidden folders are excluded or a sub folder is excluded
+- Update translations
+- Remove notDirectory translation
+- Create common template for rootfolder error and invalid view

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-workspace-sidebar",
   "description": "Adds a sidebar to VSCode that lists Workspaces and lets you open them in the current window or a new window.",
   "displayName": "Workspace Sidebar",
-  "version": "2.0.0-beta-9",
+  "version": "2.0.0-beta-11",
   "activationEvents": [
     "onStartupFinished"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vsc-workspace-sidebar",
   "description": "Adds a sidebar to VSCode that lists Workspaces and lets you open them in the current window or a new window.",
   "displayName": "Workspace Sidebar",
-  "version": "2.0.0-beta-8",
+  "version": "2.0.0-beta-9",
   "activationEvents": [
     "onStartupFinished"
   ],

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -137,7 +137,8 @@
       }
     },
     "loading": {
-      "description": "Wenn dies lange dauert, versuchen Sie, ",
+      "descriptionWithHidden": "Wenn dies lange dauert, versuchen Sie, {{settingsLinkRootFolder}} oder {{settingsLinkHidden}} auszuschließen",
+      "description": "Wenn dies lange dauert, versuchen Sie, {{settingsLinkRootFolder}} auszuschließen.",
       "title": "Arbeitsbereiche wird gesucht..."
     }
   }

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -47,7 +47,7 @@
     },
     "inValid": {
       "default": {
-        "title": "Beim Suchen nach Arbeitsbereichen ist ein Fehler aufgetreten"
+        "title": "Beim Suchen nach Arbeitsbereichen ist ein Fehler aufgetreten."
       },
       "hiddenExcluded": {
         "description": "Die Einstellungen schließen derzeit {{settingsLinkHidden}} aus.",
@@ -80,6 +80,9 @@
       "rootFolders": "Stammordner"
     },
     "list": {
+      "default": {
+        "title": "Beim Suchen nach Arbeitsbereichen ist ein Fehler aufgetreten."
+      },
       "extWs": {
         "saveButton": "Zu Stammordnern hinzufügen"
       },

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -49,21 +49,35 @@
       "default": {
         "title": "Beim Suchen nach Arbeitsbereichen ist ein Fehler aufgetreten"
       },
-      "noRootFolders": {
-        "title": "Keine Stammordner angegeben. Bitte bearbeiten Sie die Konfigurationsoption 'workspaceSidebar.rootFolders'."
+      "hiddenExcluded": {
+        "description": "Die Einstellungen schließen derzeit {{settingsLinkHidden}} aus.",
+        "title": "Alle Stammordner enthalten versteckte Ordner."
       },
-      "notDirectory": {
-        "title": "Keiner der Stammordner ist ein Verzeichnis"
+      "isFile": {
+        "description": "Überprüfen Sie, ob den {{settingsLink}} tatsächlich ein Ordner ist",
+        "title": "Keiner der Stammordner ist ein Verzeichnis."
+      },
+      "nonexistent": {
+        "description": "Überprüfen Sie die Pfade zu {{settingsLink}}.",
+        "title": "Keiner der Stammordner existiert."
+      },
+      "noRootFolders": {
+        "description": "Geben Sie einen oder mehrere {{settingsLink}} an, in denen nach Arbeitsbereichen gesucht werden soll.",
+        "title": "Keine Stammordner angegeben."
       },
       "noWorkspaces": {
-        "hintDepth": "Die aktuelle Suchtiefe ist 0, dass nur die Stammordner nach Arbeitsbereichsdateien durchsucht werden",
-        "hintSettings": "Versuchen Sie, die Suchtiefe zu erhöhen oder die Ordner zu ändern.",
+        "descriptionDepth": "Die aktuelle Suchtiefe ist 0, dass nur die Stammordner nach Arbeitsbereichsdateien durchsucht werden",
+        "descriptionSettings": "Versuchen Sie, die {{settingsLinkDepth}} zu erhöhen oder die {{settingsLinkRootFolder}} zu ändern.",
         "title": "Keine Arbeitsbereiche gefunden"
       }
     },
     "links": {
       "checkSettings": "Überprüfen Sie die Erweiterungseinstellungen",
-      "excludeFolders": "Ordner auszuschließen"
+      "depth": "Tiefe",
+      "excludeFolders": "Ordner auszuschließen",
+      "excludeHiddenFolders": "versteckter Ordner",
+      "rootFolder": "Stammordner",
+      "rootFolders": "Stammordner"
     },
     "list": {
       "extWs": {
@@ -77,6 +91,14 @@
         "open": "Derzeit offener Ordner:",
         "saveButton": "Als neuen Arbeitsbereich speichern"
       },
+      "hiddenExcluded": {
+        "description": "Die Einstellungen schließen derzeit {{settingsLinkHidden}} aus.",
+        "title": "Der Ordnerpfad enthält versteckte Ordner."
+      },
+      "isFile": {
+        "description": "Überprüfen Sie, ob den {{settingsLink}} tatsächlich ein Ordner ist",
+        "title": "Der Stammordner ist eine Datei, kein Verzeichnis."
+      },
       "itemButtons": {
         "newWindow": {
           "openCurWin": "'{{label}}' in diesem Fenster öffnen",
@@ -89,8 +111,9 @@
           "tooltip": "Öffnen Sie den Ordner '{{label}}' in Ihrem Dateimanager"
         }
       },
-      "notDirectory": {
-        "title": "Der Ordner ist kein Verzeichnis"
+      "nonexistent": {
+        "description": "Überprüfen Sie der Pfad zu {{settingsLink}}.",
+        "title": "Der Stammordner existiert nicht."
       },
       "noWorkspaces": {
         "hintDepth": "Die aktuelle Suchtiefe ist 0, das bedeutet, dass keine Unterordner durchsucht werden.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -47,29 +47,37 @@
     },
     "inValid": {
       "default": {
-        "title": "Something went wrong whilst collecting workspaces"
+        "title": "Something went wrong whilst collecting workspaces."
+      },
+      "hiddenExcluded": {
+        "description": "Settings currently exclude {{settingsLinkHidden}}.",
+        "title": "All of the root folders contain hidden folders."
       },
       "isFile": {
-        "title": "The folder is a file, not a directory"
+        "description": "Check that the {{settingsLink}} are actually folders",
+        "title": "All of the root folders are files."
       },
       "nonexistent": {
-        "title": "The folder does not exist."
+        "description": "Check the paths to the {{settingsLink}}.",
+        "title": "None of the root folders exist."
       },
       "noRootFolders": {
-        "title": "No root folders specified. Please edit the config option 'workspaceSidebar.rootFolders'"
-      },
-      "notDirectory": {
-        "title": "None of the root folders are directories"
+        "description": "Specify one or more {{settingsLink}} in which to look for workspaces.",
+        "title": "No root folders specified."
       },
       "noWorkspaces": {
-        "hintDepth": "The current search depth is 0, this means that only the root folders will be searched in for workspace files.",
-        "hintSettings": "Try increasing the search depth or change the folders.",
+        "descriptionDepth": "The current search depth is 0, this means that only the root folders will be searched in for workspace files.",
+        "descriptionSettings": "Try increasing the {{settingsLinkDepth}} or change the {{settingsLinkRootFolder}}.",
         "title": "Folders contain no workspaces"
       }
     },
     "links": {
       "checkSettings": "Check extension settings",
-      "excludeFolders": "exclude folders"
+      "depth": "depth",
+      "excludeFolders": "specific folders",
+      "excludeHiddenFolders": "hidden folders",
+      "rootFolder": "root folder",
+      "rootFolders": "root folders"
     },
     "list": {
       "extWs": {
@@ -83,8 +91,13 @@
         "open": "Current open folder:",
         "saveButton": "Save as new Workspace"
       },
+      "hiddenExcluded": {
+        "description": "Settings currently exclude {{settingsLinkHidden}}.",
+        "title": "The folder path contains hidden folders."
+      },
       "isFile": {
-        "title": "The folder is a file, not a directory"
+        "description": "Check that the {{settingsLink}} is actually a folder.",
+        "title": "The folder is a file not a directory."
       },
       "itemButtons": {
         "newWindow": {
@@ -99,15 +112,13 @@
         }
       },
       "nonexistent": {
+        "description": "Check the path to the {{settingsLink}}.",
         "title": "The folder does not exist."
       },
-      "notDirectory": {
-        "title": "The folder is not a directory"
-      },
       "noWorkspaces": {
-        "hintDepth": "The current search depth is 0, this means that no subfolders are searched.",
-        "hintSettings": "Try increasing the search depth or change the folder path.",
-        "title": "No workspace files found"
+        "descriptionDepth": "The current search depth is 0, this means that no subfolders are searched.",
+        "descriptionSettings": "Try increasing the {{settingsLinkDepth}} or change the {{settingsLinkRootFolder}} path.",
+        "title": "No workspace files found."
       },
       "search": {
         "ariaLabel": "Search Workspaces",
@@ -126,7 +137,8 @@
       }
     },
     "loading": {
-      "description": "If this is taking a long time, try and ",
+      "hintExclude": "If this is taking a long time, try and exclude",
+      "hintHiddenFolders": " or ",
       "title": "Collecting workspaces..."
     }
   }

--- a/package.nls.json
+++ b/package.nls.json
@@ -66,7 +66,7 @@
         "title": "No root folders specified."
       },
       "noWorkspaces": {
-        "descriptionDepth": "The current search depth is 0, this means that only the root folders will be searched in for workspace files.",
+        "descriptionDepth": "The current search depth is 0 for all root folders, this means that no subfolders are searched in for workspace files.",
         "descriptionSettings": "Try increasing the {{settingsLinkDepth}} or change the {{settingsLinkRootFolder}}.",
         "title": "Folders contain no workspaces"
       }
@@ -116,7 +116,7 @@
         "title": "The folder does not exist."
       },
       "noWorkspaces": {
-        "descriptionDepth": "The current search depth is 0, this means that no subfolders are searched.",
+        "descriptionDepth": "The current search depth is 0, this means that no subfolders are searched in for workspace files.",
         "descriptionSettings": "Try increasing the {{settingsLinkDepth}} or change the {{settingsLinkRootFolder}} path.",
         "title": "No workspace files found."
       },
@@ -137,8 +137,8 @@
       }
     },
     "loading": {
-      "hintExclude": "If this is taking a long time, try and exclude",
-      "hintHiddenFolders": " or ",
+      "descriptionWithHidden": "If this is taking a long time, try and exclude {{settingsLinkRootFolder}} or {{settingsLinkHidden}}.",
+      "description": "If this is taking a long time, try and exclude {{settingsLinkRootFolder}}.",
       "title": "Collecting workspaces..."
     }
   }

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,10 +39,10 @@
   "workspace": {
     "error": {
       "default": {
-        "title": "An unknown error occured"
+        "title": "An unknown error occured."
       },
       "fetch": {
-        "title": "An error occured whilst collecting workspace files"
+        "title": "An error occured whilst collecting workspace files."
       }
     },
     "inValid": {
@@ -80,6 +80,9 @@
       "rootFolders": "root folders"
     },
     "list": {
+      "default": {
+        "title": "Something went wrong whilst collecting workspaces."
+      },
       "extWs": {
         "saveButton": "Add to Root Folders"
       },

--- a/package.nls.json
+++ b/package.nls.json
@@ -49,6 +49,12 @@
       "default": {
         "title": "Something went wrong whilst collecting workspaces"
       },
+      "isFile": {
+        "title": "The folder is a file, not a directory"
+      },
+      "nonexistent": {
+        "title": "The folder does not exist."
+      },
       "noRootFolders": {
         "title": "No root folders specified. Please edit the config option 'workspaceSidebar.rootFolders'"
       },
@@ -77,6 +83,9 @@
         "open": "Current open folder:",
         "saveButton": "Save as new Workspace"
       },
+      "isFile": {
+        "title": "The folder is a file, not a directory"
+      },
       "itemButtons": {
         "newWindow": {
           "openCurWin": "Open '{{label}}' in this window",
@@ -88,6 +97,9 @@
           "ariaLabel": "Open folder containing '{{label}}' in your file manager",
           "tooltip": "Open folder containing '{{label}}' in your file manager"
         }
+      },
+      "nonexistent": {
+        "title": "The folder does not exist."
       },
       "notDirectory": {
         "title": "The folder is not a directory"

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,6 +1,8 @@
 export const CONFIG_CLEAN_LABELS = true
 export const CONFIG_CONDENSE_FILETREE = true
 export const CONFIG_DEPTH = 0
+export const CONFIG_DEPTH_MIN = 0
+export const CONFIG_DEPTH_MAX = 25
 export const CONFIG_EXCLUDED_FOLDERS = []
 export const CONFIG_EXPLORER_COMPACT_FOLDERS = true
 export const CONFIG_FOLDER = ''

--- a/src/templates/common/snippets/viewMsg.ts
+++ b/src/templates/common/snippets/viewMsg.ts
@@ -1,0 +1,38 @@
+type ViewMsgCommonProps = {
+  isSmall?: boolean
+  message: string | string[]
+}
+
+type ViewMsgDescriptionProps = {
+  iconType?: never
+  type: 'description'
+} & ViewMsgCommonProps
+
+type ViewMsgTitleProps = {
+  iconType?: 'error' | 'loading'
+  type: 'title'
+} & ViewMsgCommonProps
+
+type ViewMsgProps = ViewMsgTitleProps | ViewMsgDescriptionProps
+
+export const viewMsg = ({
+  iconType = 'error',
+  isSmall = false,
+  message,
+  type,
+}: ViewMsgProps): string => {
+  const classes = `view__message-${type}${isSmall ? ` view__message-description--tinytext` : ''}`
+  const iconClasses =
+    iconType === 'loading' ? 'codicon-loading codicon-modifier-spin' : 'codicon-error'
+  const content =
+    typeof message === 'string' ? message : message.length === 1 ? message[0] : message.join('\n')
+
+  return `
+    <p class="view__message">
+      <span class="${classes}">
+        ${type === 'title' ? `<span class="view__message-icon codicon ${iconClasses}"></span>` : ''}
+        ${content}
+      </span>
+    </p>
+  `
+}

--- a/src/templates/helpers/getRenderVars.ts
+++ b/src/templates/helpers/getRenderVars.ts
@@ -2,7 +2,6 @@ import { getFileiconThemeConfig } from '../../config/core'
 import {
   getActionsConfig,
   getCleanLabelsConfig,
-  getDepthConfig,
   getShowFileiconConfig,
   getShowFileiconsConfigConfig,
 } from '../../config/general'
@@ -64,7 +63,6 @@ export const getRenderVars = (
     cleanLabels,
     clickAction: getActionsConfig(),
     condenseFileTree: getCondenseFileTreeConfig(),
-    depth: getDepthConfig(),
     fileIconKeys,
     fileIconsActive,
     isExternalWs: isExternalWs(state),

--- a/src/templates/workspace/snippets/hoverNotification.ts
+++ b/src/templates/workspace/snippets/hoverNotification.ts
@@ -9,7 +9,7 @@ interface NotificationProps {
 export const hoverNotification = ({ message, title }: NotificationProps): string => {
   return `
       <div class="hover-notification hover-notification--loading">
-        <span class="hover-notification__icon view__message-icon ">
+        <span class="hover-notification__icon view__message-icon">
           <span class="codicon codicon-loading codicon-modifier-spin"></span>
         </span>
         <div class="hover-notification__text">

--- a/src/templates/workspace/snippets/list.ts
+++ b/src/templates/workspace/snippets/list.ts
@@ -11,7 +11,7 @@ import { itemFolder } from './itemFolder'
 import { rootFolderMessage } from './rootFolderMessage'
 import { tree } from './tree'
 
-const rootPathErrors: FindFileResult[] = [
+export const rootPathErrors: FindFileResult[] = [
   'is-file',
   'is-hidden-excluded',
   'no-workspaces',

--- a/src/templates/workspace/snippets/list.ts
+++ b/src/templates/workspace/snippets/list.ts
@@ -11,7 +11,12 @@ import { itemFolder } from './itemFolder'
 import { rootFolderMessage } from './rootFolderMessage'
 import { tree } from './tree'
 
-const rootPathErrors: FindFileResult[] = ['is-file', 'no-workspaces', 'nonexistent']
+const rootPathErrors: FindFileResult[] = [
+  'is-file',
+  'is-hidden-excluded',
+  'no-workspaces',
+  'nonexistent',
+]
 
 export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
   const { fileCount, rootFolders, search, visibleFileCount } = state
@@ -40,8 +45,8 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
             }
 
             const isFileTree = showTree && fileTree !== null
-            const classes = getListClasses(isFileTree)
             const isRootPathError = rootPathErrors.includes(result)
+            const classes = getListClasses(isFileTree)
             const isClosed = closedFolders.includes(folderName)
             const rootFolderFile: FileTree = {
               files: [],

--- a/src/templates/workspace/snippets/list.ts
+++ b/src/templates/workspace/snippets/list.ts
@@ -1,5 +1,8 @@
 import { t } from 'vscode-ext-localisation'
-import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
+import {
+  FindFileResult,
+  WorkspaceState,
+} from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { FileTree } from '../../../webviews/Workspace/helpers/getFileTree'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { getListClasses } from '../../helpers/getListClasses'
@@ -7,6 +10,8 @@ import { itemFile } from './itemFile'
 import { itemFolder } from './itemFolder'
 import { rootFolderMessage } from './rootFolderMessage'
 import { tree } from './tree'
+
+const rootPathErrors: FindFileResult[] = ['is-file', 'no-workspaces', 'nonexistent']
 
 export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
   const { fileCount, rootFolders, search, visibleFileCount } = state
@@ -36,7 +41,7 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
 
             const isFileTree = showTree && fileTree !== null
             const classes = getListClasses(isFileTree)
-            let isRootPathError = result === 'invalid-folder' || result === 'no-workspaces'
+            const isRootPathError = rootPathErrors.includes(result)
             const isClosed = closedFolders.includes(folderName)
             const rootFolderFile: FileTree = {
               files: [],

--- a/src/templates/workspace/snippets/list.ts
+++ b/src/templates/workspace/snippets/list.ts
@@ -37,7 +37,7 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
       <div class="list__list-wrapper">
         ${rootFolders
           .map((rootFolder) => {
-            const { closedFolders, fileTree, folderName, folderPath, result, visibleFiles } =
+            const { closedFolders, depth, fileTree, folderName, folderPath, result, visibleFiles } =
               rootFolder
 
             if (search.term && visibleFiles.length < 1) {
@@ -70,7 +70,7 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
                         renderVars,
                         state,
                       })}
-                      ${rootFolderMessage(result, renderVars)}
+                      ${rootFolderMessage(result, depth)}
                     `
                     : ''
                 }

--- a/src/templates/workspace/snippets/rootFolderMessage.ts
+++ b/src/templates/workspace/snippets/rootFolderMessage.ts
@@ -7,7 +7,7 @@ export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: numbe
   switch (result) {
     case 'is-hidden-excluded':
       return `
-        <div class="rootfolder__message">
+        <div class="rootfolder__message" data-type="${result}">
           ${viewMsg({ message: t('workspace.list.hiddenExcluded.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.list.hiddenExcluded.description', {
@@ -23,7 +23,7 @@ export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: numbe
 
     case 'nonexistent':
       return `
-        <div class="rootfolder__message">
+        <div class="rootfolder__message" data-type="${result}">
           ${viewMsg({ message: t('workspace.list.nonexistent.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.list.nonexistent.description', {
@@ -36,7 +36,7 @@ export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: numbe
 
     case 'is-file':
       return `
-          <div class="rootfolder__message">
+          <div class="rootfolder__message" data-type="${result}">
             ${viewMsg({ message: t('workspace.list.isFile.title'), type: 'title' })}
             ${viewMsg({
               message: t('workspace.list.isFile.description', {
@@ -48,11 +48,10 @@ export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: numbe
         `
 
     case 'no-workspaces':
-    default:
       const isDepthZero = rootFolderDepth === 0
 
       return `
-        <div class="rootfolder__message">
+        <div class="rootfolder__message" data-type="${result}">
           ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.list.noWorkspaces.descriptionSettings', {
@@ -71,5 +70,12 @@ export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: numbe
           }
         </div>
       `
+
+    default:
+      return `
+        <div class="rootfolder__message rootfolder__message--default" data-type="${result}">
+          ${viewMsg({ message: t('workspace.list.default.title'), type: 'title' })}
+        </div>
+        `
   }
 }

--- a/src/templates/workspace/snippets/rootFolderMessage.ts
+++ b/src/templates/workspace/snippets/rootFolderMessage.ts
@@ -1,16 +1,39 @@
 import { t } from 'vscode-ext-localisation'
 import { FindFileResult } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
+import { viewLink } from '../../common/snippets/viewLink'
 import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars): string => {
   const isDepthZero = renderVars.depth === 0
 
   switch (result) {
+    case 'is-hidden-excluded':
+      return `
+        <div class="rootfolder__message">
+          ${viewMsg({ message: t('workspace.list.hiddenExcluded.title'), type: 'title' })}
+          ${viewMsg({
+            message: t('workspace.list.hiddenExcluded.description', {
+              settingsLinkHidden: viewLink(
+                t('workspace.links.excludeHiddenFolders'),
+                'EXCLUDE_HIDDEN_FOLDERS'
+              ),
+            }),
+            type: 'description',
+          })}
+        </div>
+      `
+
     case 'nonexistent':
       return `
         <div class="rootfolder__message">
           ${viewMsg({ message: t('workspace.list.nonexistent.title'), type: 'title' })}
+          ${viewMsg({
+            message: t('workspace.list.nonexistent.description', {
+              settingsLink: viewLink(t('workspace.links.rootFolder'), 'ROOT_FOLDERS'),
+            }),
+            type: 'description',
+          })}
         </div>
       `
 
@@ -18,6 +41,12 @@ export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars
       return `
           <div class="rootfolder__message">
             ${viewMsg({ message: t('workspace.list.isFile.title'), type: 'title' })}
+            ${viewMsg({
+              message: t('workspace.list.isFile.description', {
+                settingsLink: viewLink(t('workspace.links.rootFolder'), 'ROOT_FOLDERS'),
+              }),
+              type: 'description',
+            })}
           </div>
         `
 
@@ -26,18 +55,21 @@ export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars
       return `
         <div class="rootfolder__message">
           ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}
+          ${viewMsg({
+            message: t('workspace.list.noWorkspaces.descriptionSettings', {
+              settingsLinkDepth: viewLink(t('workspace.links.depth'), 'DEPTH'),
+              settingsLinkRootFolder: viewLink(t('workspace.links.rootFolder'), 'ROOT_FOLDERS'),
+            }),
+            type: 'description',
+          })}
           ${
             isDepthZero
               ? viewMsg({
-                  message: t('workspace.list.noWorkspaces.hintDepth'),
+                  message: t('workspace.list.noWorkspaces.descriptionDepth'),
                   type: 'description',
                 })
               : ''
           }
-          ${viewMsg({
-            message: t('workspace.list.noWorkspaces.hintSettings'),
-            type: 'description',
-          })}
         </div>
       `
   }

--- a/src/templates/workspace/snippets/rootFolderMessage.ts
+++ b/src/templates/workspace/snippets/rootFolderMessage.ts
@@ -1,12 +1,9 @@
 import { t } from 'vscode-ext-localisation'
 import { FindFileResult } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
-import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
 import { viewMsg } from '../../common/snippets/viewMsg'
 
-export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars): string => {
-  const isDepthZero = renderVars.depth === 0
-
+export const rootFolderMessage = (result: FindFileResult, rootFolderDepth: number): string => {
   switch (result) {
     case 'is-hidden-excluded':
       return `
@@ -52,6 +49,8 @@ export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars
 
     case 'no-workspaces':
     default:
+      const isDepthZero = rootFolderDepth === 0
+
       return `
         <div class="rootfolder__message">
           ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}

--- a/src/templates/workspace/snippets/rootFolderMessage.ts
+++ b/src/templates/workspace/snippets/rootFolderMessage.ts
@@ -1,48 +1,43 @@
 import { t } from 'vscode-ext-localisation'
 import { FindFileResult } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
+import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const rootFolderMessage = (result: FindFileResult, renderVars: RenderVars): string => {
   const isDepthZero = renderVars.depth === 0
 
   switch (result) {
-    case 'invalid-folder':
+    case 'nonexistent':
       return `
         <div class="rootfolder__message">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.list.notDirectory.title')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.list.nonexistent.title'), type: 'title' })}
         </div>
       `
+
+    case 'is-file':
+      return `
+          <div class="rootfolder__message">
+            ${viewMsg({ message: t('workspace.list.isFile.title'), type: 'title' })}
+          </div>
+        `
 
     case 'no-workspaces':
     default:
       return `
         <div class="rootfolder__message">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.list.noWorkspaces.title')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}
           ${
             isDepthZero
-              ? `
-                <p class="view__message">
-                  <span class="view__message-description">
-                    ${t('workspace.list.noWorkspaces.hintDepth')}
-                  </span>
-                </p>`
+              ? viewMsg({
+                  message: t('workspace.list.noWorkspaces.hintDepth'),
+                  type: 'description',
+                })
               : ''
           }
-          <p class="view__message">
-            <span class="view__message-description">
-              ${t('workspace.list.noWorkspaces.hintSettings')}
-            </span>
-          </p>
+          ${viewMsg({
+            message: t('workspace.list.noWorkspaces.hintSettings'),
+            type: 'description',
+          })}
         </div>
       `
   }

--- a/src/templates/workspace/templates/defaultTemplate.ts
+++ b/src/templates/workspace/templates/defaultTemplate.ts
@@ -43,6 +43,7 @@ export const defaultTemplate = (templateVars: TemplateVars, state: WorkspaceStat
   } else {
     content = errorView(state, renderVars)
   }
+  content = invalidView(state, renderVars)
 
   return `
     <!DOCTYPE html>

--- a/src/templates/workspace/templates/defaultTemplate.ts
+++ b/src/templates/workspace/templates/defaultTemplate.ts
@@ -43,7 +43,6 @@ export const defaultTemplate = (templateVars: TemplateVars, state: WorkspaceStat
   } else {
     content = errorView(state, renderVars)
   }
-  content = invalidView(state, renderVars)
 
   return `
     <!DOCTYPE html>

--- a/src/templates/workspace/views/errorView.ts
+++ b/src/templates/workspace/views/errorView.ts
@@ -22,7 +22,7 @@ export const errorView = (state: WorkspaceState, renderVars: RenderVars): string
       ${
         showStackTrace
           ? viewMsg({
-              message: errorObj.stack || '',
+              message: errorObj?.stack ?? '',
               isSmall: true,
               type: 'description',
             })

--- a/src/templates/workspace/views/errorView.ts
+++ b/src/templates/workspace/views/errorView.ts
@@ -2,6 +2,7 @@ import { t } from 'vscode-ext-localisation'
 import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
+import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const errorView = (state: WorkspaceState, renderVars: RenderVars): string => {
   const { error, errorObj } = state
@@ -10,26 +11,23 @@ export const errorView = (state: WorkspaceState, renderVars: RenderVars): string
 
   return `
     <section class="view error">
-      <p class="view__message">
-        <span class="view__message-title">
-          <span class="view__message-icon codicon codicon-error"></span>
-          ${isFetch ? t('workspace.error.fetch.title') : t('workspace.error.default.title')}
-        </span>
-      </p>
-      <p class="view__message">
-        <span class="view__message-description">
-          ${viewLink(t('workspace.links.checkSettings'), 'SETTINGS')}
-        </span>
-      </p>
+      ${viewMsg({
+        message: isFetch ? t('workspace.error.fetch.title') : t('workspace.error.default.title'),
+        type: 'title',
+      })}
+      ${viewMsg({
+        message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+        type: 'description',
+      })}
       ${
         showStackTrace
-          ? `
-          <p class="view__message">
-            <span class="view__message-description view__message-description--tinytext{">
-              ${errorObj.stack || ''}
-            </span>
-          </p>`
+          ? viewMsg({
+              message: errorObj.stack || '',
+              isSmall: true,
+              type: 'description',
+            })
           : ''
       }
-    </section>`
+    </section>
+  `
 }

--- a/src/templates/workspace/views/invalidView.ts
+++ b/src/templates/workspace/views/invalidView.ts
@@ -5,8 +5,6 @@ import { viewLink } from '../../common/snippets/viewLink'
 import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const invalidView = (state: WorkspaceState, renderVars: RenderVars): string => {
-  const isDepthZero = renderVars.depth === 0
-
   switch (state.result) {
     case 'is-hidden-excluded':
       return `
@@ -64,6 +62,17 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
       `
 
     case 'no-workspaces':
+      let isDepthZero = true
+
+      for (let index = 0; index < state.workspaceData.length; index++) {
+        const { depth } = state.workspaceData[index]
+
+        if (depth > 0) {
+          isDepthZero = false
+          break
+        }
+      }
+
       return `
         <section class="view invalid">
           ${viewMsg({ message: t('workspace.inValid.noWorkspaces.title'), type: 'title' })}
@@ -75,7 +84,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
             type: 'description',
           })}
           ${
-            !isDepthZero
+            isDepthZero
               ? viewMsg({
                   message: t('workspace.inValid.noWorkspaces.descriptionDepth'),
                   type: 'description',

--- a/src/templates/workspace/views/invalidView.ts
+++ b/src/templates/workspace/views/invalidView.ts
@@ -8,12 +8,30 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
   const isDepthZero = renderVars.depth === 0
 
   switch (state.result) {
+    case 'is-hidden-excluded':
+      return `
+        <section class="view invalid">
+          ${viewMsg({ message: t('workspace.inValid.hiddenExcluded.title'), type: 'title' })}
+          ${viewMsg({
+            message: t('workspace.inValid.hiddenExcluded.description', {
+              settingsLinkHidden: viewLink(
+                t('workspace.links.excludeHiddenFolders'),
+                'EXCLUDE_HIDDEN_FOLDERS'
+              ),
+            }),
+            type: 'description',
+          })}
+        </section>
+      `
+
     case 'nonexistent':
       return `
         <section class="view invalid">
           ${viewMsg({ message: t('workspace.inValid.nonexistent.title'), type: 'title' })}
           ${viewMsg({
-            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            message: t('workspace.inValid.nonexistent.description', {
+              settingsLink: viewLink(t('workspace.links.rootFolders'), 'ROOT_FOLDERS'),
+            }),
             type: 'description',
           })}
         </section>
@@ -24,7 +42,9 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
         <section class="view invalid">
           ${viewMsg({ message: t('workspace.inValid.isFile.title'), type: 'title' })}
           ${viewMsg({
-            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            message: t('workspace.inValid.isFile.description', {
+              settingsLink: viewLink(t('workspace.links.rootFolders'), 'ROOT_FOLDERS'),
+            }),
             type: 'description',
           })}
         </section>
@@ -35,7 +55,9 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
         <section class="view invalid">
           ${viewMsg({ message: t('workspace.inValid.noRootFolders.title'), type: 'title' })}
           ${viewMsg({
-            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            message: t('workspace.inValid.noRootFolders.description', {
+              settingsLink: viewLink(t('workspace.links.rootFolders'), 'ROOT_FOLDERS'),
+            }),
             type: 'description',
           })}
         </section>
@@ -45,22 +67,21 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
       return `
         <section class="view invalid">
           ${viewMsg({ message: t('workspace.inValid.noWorkspaces.title'), type: 'title' })}
+          ${viewMsg({
+            message: t('workspace.inValid.noWorkspaces.descriptionSettings', {
+              settingsLinkDepth: viewLink(t('workspace.links.depth'), 'DEPTH'),
+              settingsLinkRootFolder: viewLink(t('workspace.links.rootFolders'), 'ROOT_FOLDERS'),
+            }),
+            type: 'description',
+          })}
           ${
-            isDepthZero
+            !isDepthZero
               ? viewMsg({
-                  message: t('workspace.inValid.noWorkspaces.hintDepth'),
+                  message: t('workspace.inValid.noWorkspaces.descriptionDepth'),
                   type: 'description',
                 })
               : ''
           }
-          ${viewMsg({
-            message: t('workspace.inValid.noWorkspaces.hintSettings'),
-            type: 'description',
-          })}
-          ${viewMsg({
-            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
-            type: 'description',
-          })}
         </section>
       `
 

--- a/src/templates/workspace/views/invalidView.ts
+++ b/src/templates/workspace/views/invalidView.ts
@@ -8,7 +8,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
   switch (state.result) {
     case 'is-hidden-excluded':
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.hiddenExcluded.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.inValid.hiddenExcluded.description', {
@@ -24,7 +24,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
 
     case 'nonexistent':
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.nonexistent.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.inValid.nonexistent.description', {
@@ -37,7 +37,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
 
     case 'is-file':
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.isFile.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.inValid.isFile.description', {
@@ -50,7 +50,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
 
     case 'no-root-folders':
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.noRootFolders.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.inValid.noRootFolders.description', {
@@ -74,7 +74,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
       }
 
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.noWorkspaces.title'), type: 'title' })}
           ${viewMsg({
             message: t('workspace.inValid.noWorkspaces.descriptionSettings', {
@@ -96,7 +96,7 @@ export const invalidView = (state: WorkspaceState, renderVars: RenderVars): stri
 
     default:
       return `
-        <section class="view invalid">
+        <section class="view invalid" data-type="${state.result}">
           ${viewMsg({ message: t('workspace.inValid.default.title'), type: 'title' })}
           ${viewMsg({
             message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),

--- a/src/templates/workspace/views/invalidView.ts
+++ b/src/templates/workspace/views/invalidView.ts
@@ -2,91 +2,76 @@ import { t } from 'vscode-ext-localisation'
 import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
+import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const invalidView = (state: WorkspaceState, renderVars: RenderVars): string => {
   const isDepthZero = renderVars.depth === 0
 
   switch (state.result) {
-    case 'invalid-folder':
+    case 'nonexistent':
       return `
         <section class="view invalid">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.inValid.notDirectory.title')}
-            </span>
-          </p>
-          <p class="view__message">
-            <span class="view__message-description">
-              ${viewLink(t('workspace.links.checkSettings'), 'SETTINGS')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.inValid.nonexistent.title'), type: 'title' })}
+          ${viewMsg({
+            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            type: 'description',
+          })}
+        </section>
+      `
+
+    case 'is-file':
+      return `
+        <section class="view invalid">
+          ${viewMsg({ message: t('workspace.inValid.isFile.title'), type: 'title' })}
+          ${viewMsg({
+            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            type: 'description',
+          })}
         </section>
       `
 
     case 'no-root-folders':
       return `
         <section class="view invalid">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.inValid.noRootFolders.title')}
-            </span>
-          </p>
-          <p class="view__message">
-            <span class="view__message-description">
-              ${viewLink(t('workspace.links.checkSettings'), 'ROOT_FOLDERS')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.inValid.noRootFolders.title'), type: 'title' })}
+          ${viewMsg({
+            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            type: 'description',
+          })}
         </section>
       `
 
     case 'no-workspaces':
       return `
         <section class="view invalid">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.inValid.noWorkspaces.title')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.inValid.noWorkspaces.title'), type: 'title' })}
           ${
             isDepthZero
-              ? `
-                <p class="view__message">
-                  <span class="view__message-description">
-                    ${t('workspace.inValid.noWorkspaces.hintDepth')}
-                  </span>
-                </p>`
+              ? viewMsg({
+                  message: t('workspace.inValid.noWorkspaces.hintDepth'),
+                  type: 'description',
+                })
               : ''
           }
-          <p class="view__message">
-            <span class="view__message-description">
-              ${t('workspace.inValid.noWorkspaces.hintSettings')}
-            </span>
-          </p>
-          <p class="view__message">
-            <span class="view__message-description">
-              ${viewLink(t('workspace.links.checkSettings'), 'SETTINGS')}
-            </span>
-          </p>
+          ${viewMsg({
+            message: t('workspace.inValid.noWorkspaces.hintSettings'),
+            type: 'description',
+          })}
+          ${viewMsg({
+            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            type: 'description',
+          })}
         </section>
       `
 
     default:
       return `
         <section class="view invalid">
-          <p class="view__message">
-            <span class="view__message-title">
-              <span class="view__message-icon codicon codicon-error"></span>
-              ${t('workspace.inValid.default.title')}
-            </span>
-          </p>
-          <p class="view__message">
-            <span class="view__message-description">
-              ${viewLink(t('workspace.links.checkSettings'), 'SETTINGS')}
-            </span>
-          </p>
+          ${viewMsg({ message: t('workspace.inValid.default.title'), type: 'title' })}
+          ${viewMsg({
+            message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+            type: 'description',
+          })}
         </section>
       `
   }

--- a/src/templates/workspace/views/listView.ts
+++ b/src/templates/workspace/views/listView.ts
@@ -3,6 +3,7 @@ import { t } from 'vscode-ext-localisation'
 import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
+import { viewMsg } from '../../common/snippets/viewMsg'
 import { externalWorkspace } from '../snippets/externalWorkspace'
 import { folderList } from '../snippets/folderList'
 import { hoverNotification } from '../snippets/hoverNotification'
@@ -30,17 +31,14 @@ export const listView = (state: WorkspaceState, renderVars: RenderVars): string 
       `
   }
 
+  // TODO - check rendering
   return `
       <section class="view list list--empty">
-        <p class="view__message">
-          <span class="view__message-title">
-            <span class="view__message-icon codicon codicon-error"></span>
-            ${t('workspace.list.empty.title')}
-          </span>
-        </p>
-        <p class="view__message">
-          ${viewLink(t('workspace.links.checkSettings'), 'SETTINGS')}
-        </p>
+        ${viewMsg({ message: t('workspace.list.empty.title'), type: 'title' })}
+        ${viewMsg({
+          message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
+          type: 'description',
+        })}
       </section>
     `
 }

--- a/src/templates/workspace/views/listView.ts
+++ b/src/templates/workspace/views/listView.ts
@@ -31,7 +31,6 @@ export const listView = (state: WorkspaceState, renderVars: RenderVars): string 
       `
   }
 
-  // TODO - check rendering
   return `
       <section class="view list list--empty">
         ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}

--- a/src/templates/workspace/views/listView.ts
+++ b/src/templates/workspace/views/listView.ts
@@ -34,7 +34,7 @@ export const listView = (state: WorkspaceState, renderVars: RenderVars): string 
   // TODO - check rendering
   return `
       <section class="view list list--empty">
-        ${viewMsg({ message: t('workspace.list.empty.title'), type: 'title' })}
+        ${viewMsg({ message: t('workspace.list.noWorkspaces.title'), type: 'title' })}
         ${viewMsg({
           message: viewLink(t('workspace.links.checkSettings'), 'SETTINGS'),
           type: 'description',

--- a/src/templates/workspace/views/loadingView.ts
+++ b/src/templates/workspace/views/loadingView.ts
@@ -7,16 +7,22 @@ import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const loadingView = (state: WorkspaceState, renderVars: RenderVars): string => {
   const excludeHiddenFoldersConfig = getExcludeHiddenFoldersConfig()
-  const message = [
-    t('workspace.loading.hintExclude'),
-    `${viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS')}.`,
+  let message = [
+    t('workspace.loading.description', {
+      settingsLinkRootFolder: viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS'),
+    }),
   ]
 
-  if (excludeHiddenFoldersConfig) {
-    message.push(t('workspace.loading.hintHiddenFolders'))
-    message.push(
-      `${viewLink(t('workspace.links.excludeHiddenFolders'), 'EXCLUDE_HIDDEN_FOLDERS')}.`
-    )
+  if (!excludeHiddenFoldersConfig) {
+    message = [
+      t('workspace.loading.descriptionWithHidden', {
+        settingsLinkRootFolder: viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS'),
+        settingsLinkHidden: viewLink(
+          t('workspace.links.excludeHiddenFolders'),
+          'EXCLUDE_HIDDEN_FOLDERS'
+        ),
+      }),
+    ]
   }
 
   return `

--- a/src/templates/workspace/views/loadingView.ts
+++ b/src/templates/workspace/views/loadingView.ts
@@ -2,21 +2,23 @@ import { t } from 'vscode-ext-localisation'
 import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
+import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const loadingView = (state: WorkspaceState, renderVars: RenderVars): string => {
   return `
     <section class="view loading">
-      <p class="view__message">
-        <span class="view__message-title">
-          <span class="view__message-icon codicon codicon-loading codicon-modifier-spin"></span>
-          ${t('workspace.loading.title')}
-        </span>
-      </p>
-      <p class="view__message">
-        <span class="view__message-description">
-          ${t('workspace.loading.description')} 
-          ${viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS')}.
-        </span>
-      </p>
-    </section>`
+      ${viewMsg({
+        message: t('workspace.loading.title'),
+        iconType: 'loading',
+        type: 'title',
+      })}
+      ${viewMsg({
+        message: [
+          t('workspace.loading.description'),
+          `${viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS')}.`,
+        ],
+        type: 'description',
+      })}
+    </section>
+  `
 }

--- a/src/templates/workspace/views/loadingView.ts
+++ b/src/templates/workspace/views/loadingView.ts
@@ -1,10 +1,24 @@
 import { t } from 'vscode-ext-localisation'
+import { getExcludeHiddenFoldersConfig } from '../../../config/folders'
 import { WorkspaceState } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
 import { viewLink } from '../../common/snippets/viewLink'
 import { viewMsg } from '../../common/snippets/viewMsg'
 
 export const loadingView = (state: WorkspaceState, renderVars: RenderVars): string => {
+  const excludeHiddenFoldersConfig = getExcludeHiddenFoldersConfig()
+  const message = [
+    t('workspace.loading.hintExclude'),
+    `${viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS')}.`,
+  ]
+
+  if (excludeHiddenFoldersConfig) {
+    message.push(t('workspace.loading.hintHiddenFolders'))
+    message.push(
+      `${viewLink(t('workspace.links.excludeHiddenFolders'), 'EXCLUDE_HIDDEN_FOLDERS')}.`
+    )
+  }
+
   return `
     <section class="view loading">
       ${viewMsg({
@@ -13,10 +27,7 @@ export const loadingView = (state: WorkspaceState, renderVars: RenderVars): stri
         type: 'title',
       })}
       ${viewMsg({
-        message: [
-          t('workspace.loading.description'),
-          `${viewLink(t('workspace.links.excludeFolders'), 'EXCLUDE_FOLDERS')}.`,
-        ],
+        message,
         type: 'description',
       })}
     </section>

--- a/src/test/mocks/mockContext.ts
+++ b/src/test/mocks/mockContext.ts
@@ -17,7 +17,7 @@ export const getMockContext = () => {
     asAbsolutePath: (relativePath: string) => relativePath,
     extension: {} as vscode.Extension<{}>,
     extensionPath,
-    environmentVariableCollection: {} as vscode.EnvironmentVariableCollection,
+    environmentVariableCollection: {} as unknown,
     extensionMode: vscode.ExtensionMode.Test,
     extensionUri: getMockUri(),
     globalState: {

--- a/src/test/mocks/mockFsStructure.ts
+++ b/src/test/mocks/mockFsStructure.ts
@@ -1,4 +1,7 @@
 export const mockFsStructure = {
+  '.hiddenfolder': {
+    'hiddenfolder.code-workspace': '',
+  },
   'check-file': {
     'test-file.txt': '',
   },
@@ -31,5 +34,15 @@ export const mockFsStructure = {
     'test-file3': '',
     'test-subfolder1': {},
     'test-subfolder2': {},
+  },
+  hideme: {
+    '.hiddenfolder': {
+      'hiddenfolder.code-workspace': '',
+    },
+  },
+  'more-workspaces': {
+    'more-sub': {
+      'WS 7.code-workspace': '',
+    },
   },
 }

--- a/src/test/mocks/mockRenderVars.ts
+++ b/src/test/mocks/mockRenderVars.ts
@@ -3,7 +3,6 @@ import { Uri } from 'vscode'
 import {
   CONFIG_CLEAN_LABELS,
   CONFIG_CONDENSE_FILETREE,
-  CONFIG_DEPTH,
   CONFIG_SEARCH_MINIMUM,
   CONFIG_SHOW_HIERARCHY,
   ConfigActions,
@@ -20,7 +19,6 @@ export const getMockRenderVars = (renderVars: Partial<RenderVars> = {}): RenderV
     cleanLabels: CONFIG_CLEAN_LABELS,
     clickAction: ConfigActions.CURRENT_WINDOW,
     condenseFileTree: CONFIG_CONDENSE_FILETREE,
-    depth: CONFIG_DEPTH,
     fileIconKeys: {},
     fileIconsActive: false,
     imgDarkFolderUri: { ...baseUri, path: path.join('/resources', 'images', 'dark') } as Uri,

--- a/src/test/mocks/mockState.ts
+++ b/src/test/mocks/mockState.ts
@@ -1,3 +1,4 @@
+import { CONFIG_DEPTH } from '../../constants/config'
 import { FindRootFolderFiles } from '../../utils/fs/findRootFolderFiles'
 import { getLastPathSegment } from '../../utils/fs/getLastPathSegment'
 import { initialSearchState, initialState } from '../../webviews/Workspace/store/workspaceSlice'
@@ -28,7 +29,7 @@ type GetMockRootFoldersConfig = {
 }
 
 export const defaultRootFolderFiles: FindRootFolderFiles[] = [
-  { files: getMockFileList(), folderPath: ROOT_FOLDER_PATH, result: 'ok' },
+  { depth: CONFIG_DEPTH, files: getMockFileList(), folderPath: ROOT_FOLDER_PATH, result: 'ok' },
 ]
 
 const defaultGetMockRootFoldersConfig: GetMockRootFoldersConfig = {
@@ -78,6 +79,7 @@ export const getMockRootFolders = (
       allFolders,
       closedFolders,
       convertedFiles,
+      depth: CONFIG_DEPTH,
       files,
       fileTree,
       folderName: getLastPathSegment(folderPath) || folderPath,

--- a/src/test/mocks/mockState.ts
+++ b/src/test/mocks/mockState.ts
@@ -47,12 +47,30 @@ export const getMockSearchState = (state: Partial<SearchState> = {}): SearchStat
   }
 }
 
-export const getMockState = (state: Partial<WorkspaceState> = {}): WorkspaceState => {
-  return {
+export const getMockState = (
+  state: Partial<WorkspaceState> = {},
+  depth = CONFIG_DEPTH
+): WorkspaceState => {
+  const workspaceData: FindRootFolderFiles[] = []
+  const newState: WorkspaceState = {
     ...initialState,
     selected: '',
     wsType: 'ws',
     ...state,
+  }
+
+  newState.rootFolders.forEach(({ files, folderPath, result }) => {
+    workspaceData.push({
+      depth,
+      files,
+      folderPath,
+      result,
+    })
+  })
+
+  return {
+    ...newState,
+    workspaceData,
   }
 }
 

--- a/src/test/suite/templates/common/snippets/viewMsg.test.ts
+++ b/src/test/suite/templates/common/snippets/viewMsg.test.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai'
+import { viewMsg } from '../../../../../templates/common/snippets/viewMsg'
+
+suite('Templates > Common > Snippets: viewMsg()', () => {
+  const message = 'The folder does not exist.'
+
+  test('Titles render as expected', () => {
+    const result = viewMsg({ message, type: 'title' })
+
+    expect(result).to.be.a('string')
+    expect(result).contains('"view__message"')
+    expect(result).contains('"view__message-title')
+    expect(result).contains('"view__message-icon codicon codicon-error"')
+
+    expect(result).contains(message)
+  })
+
+  test('Descriptions render as expected', () => {
+    const result = viewMsg({ message, type: 'description' })
+
+    expect(result).to.be.a('string')
+    expect(result).contains('"view__message"')
+    expect(result).contains('"view__message-description')
+    expect(result).contains(message)
+  })
+
+  test('isSmall adds tinytext class', () => {
+    const result = viewMsg({ isSmall: true, message, type: 'title' })
+    expect(result).contains('view__message-description--tinytext')
+  })
+
+  test('Icon is not shown for descriptions', () => {
+    const result = viewMsg({ message, type: 'description' })
+    expect(result).not.contains('"view__message-icon codicon')
+  })
+
+  test('iconType "error" shows the correct icon', () => {
+    const result = viewMsg({ iconType: 'error', message, type: 'title' })
+    expect(result).contains('"view__message-icon codicon codicon-error"')
+  })
+
+  test('iconType "loading" shows the correct icon', () => {
+    const result = viewMsg({ iconType: 'loading', message, type: 'title' })
+    expect(result).contains('"view__message-icon codicon codicon-loading codicon-modifier-spin"')
+  })
+})

--- a/src/test/suite/templates/helpers/getRenderVars.test.ts
+++ b/src/test/suite/templates/helpers/getRenderVars.test.ts
@@ -77,7 +77,6 @@ suite('Templates > Helpers > getRenderVars():', () => {
 
     expect(result.clickAction).to.eql(ConfigActions.CURRENT_WINDOW)
     expect(result.condenseFileTree).to.eql(CONFIG_CONDENSE_FILETREE)
-    expect(result.depth).to.eql(CONFIG_DEPTH)
     expect(result.searchMinimum).to.eql(CONFIG_SEARCH_MINIMUM)
     expect(result.showTree).to.eql(CONFIG_SHOW_HIERARCHY)
   })

--- a/src/test/suite/templates/workspace/snippets/list.test.ts
+++ b/src/test/suite/templates/workspace/snippets/list.test.ts
@@ -106,8 +106,8 @@ suite('Templates > Workspace > Snippets: list()', () => {
     sinon.assert.notCalled(treeSpy)
   })
 
-  test('Renders rootFolderMessage if rootFolder.result is "invalid-folder"', () => {
-    const mockRootFolders = getMockRootFolders({
+  test.skip('Renders rootFolderMessage if rootFolder.result is "invalid-folder"', () => {
+    /*     const mockRootFolders = getMockRootFolders({
       rootFoldersFiles: [{ ...defaultRootFolderFiles[0], result: 'invalid-folder' }],
       showTree: false,
     })
@@ -120,7 +120,7 @@ suite('Templates > Workspace > Snippets: list()', () => {
     sinon.assert.called(rfMsg)
     sinon.assert.called(itemFolderSpy)
     sinon.assert.notCalled(itemSpy)
-    sinon.assert.notCalled(treeSpy)
+    sinon.assert.notCalled(treeSpy) */
   })
 
   test('Renders rootFolderMessage if rootFolder.result is "no-workspaces"', () => {

--- a/src/test/suite/templates/workspace/snippets/list.test.ts
+++ b/src/test/suite/templates/workspace/snippets/list.test.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import * as sinon from 'sinon'
 import * as item from '../../../../../templates/workspace/snippets/itemFile'
 import * as itemFolder from '../../../../../templates/workspace/snippets/itemFolder'
-import { list } from '../../../../../templates/workspace/snippets/list'
+import { list, rootPathErrors } from '../../../../../templates/workspace/snippets/list'
 import * as rfm from '../../../../../templates/workspace/snippets/rootFolderMessage'
 import * as tree from '../../../../../templates/workspace/snippets/tree'
 import { OS_HOMEFOLDER, SEARCH_TERM } from '../../../../mocks/mockFileData'
@@ -106,37 +106,22 @@ suite('Templates > Workspace > Snippets: list()', () => {
     sinon.assert.notCalled(treeSpy)
   })
 
-  test.skip('Renders rootFolderMessage if rootFolder.result is "invalid-folder"', () => {
-    /*     const mockRootFolders = getMockRootFolders({
-      rootFoldersFiles: [{ ...defaultRootFolderFiles[0], result: 'invalid-folder' }],
-      showTree: false,
+  rootPathErrors.forEach((res) => {
+    test(`Renders rootFolderMessage if rootFolder.result is "${res}"`, () => {
+      const mockRootFolders = getMockRootFolders({
+        rootFoldersFiles: [{ ...defaultRootFolderFiles[0], result: res }],
+        showTree: false,
+      })
+      const mockState = getMockState({ ...mockRootFolders })
+      const mockRenderVars = getMockRenderVars({ showTree: true })
+
+      const result = list(mockState, mockRenderVars)
+
+      expect(result).to.be.a('string')
+      sinon.assert.called(rfMsg)
+      sinon.assert.called(itemFolderSpy)
+      sinon.assert.notCalled(itemSpy)
+      sinon.assert.notCalled(treeSpy)
     })
-    const mockState = getMockState({ ...mockRootFolders })
-    const mockRenderVars = getMockRenderVars({ showTree: true })
-
-    const result = list(mockState, mockRenderVars)
-
-    expect(result).to.be.a('string')
-    sinon.assert.called(rfMsg)
-    sinon.assert.called(itemFolderSpy)
-    sinon.assert.notCalled(itemSpy)
-    sinon.assert.notCalled(treeSpy) */
-  })
-
-  test('Renders rootFolderMessage if rootFolder.result is "no-workspaces"', () => {
-    const mockRootFolders = getMockRootFolders({
-      rootFoldersFiles: [{ ...defaultRootFolderFiles[0], result: 'no-workspaces' }],
-      showTree: false,
-    })
-    const mockState = getMockState({ ...mockRootFolders })
-    const mockRenderVars = getMockRenderVars({ showTree: true })
-
-    const result = list(mockState, mockRenderVars)
-
-    expect(result).to.be.a('string')
-    sinon.assert.called(rfMsg)
-    sinon.assert.called(itemFolderSpy)
-    sinon.assert.notCalled(itemSpy)
-    sinon.assert.notCalled(treeSpy)
   })
 })

--- a/src/test/suite/templates/workspace/snippets/rootFolderMessage.test.ts
+++ b/src/test/suite/templates/workspace/snippets/rootFolderMessage.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
+import { rootFolderMessage } from '../../../../../templates/workspace/snippets/rootFolderMessage'
+import { FindFileResult } from '../../../../../webviews/Workspace/WorkspaceViewProvider.interface'
+
+suite.only('Templates > Workspace > Snippets: rootFolderMessage()', () => {
+  const results: FindFileResult[] = [
+    'is-file',
+    'is-hidden-excluded',
+    'no-workspaces',
+    'nonexistent',
+  ]
+
+  results.forEach((res) => {
+    test(`"${res}" renders expected message`, () => {
+      const result = rootFolderMessage(res, CONFIG_DEPTH)
+
+      expect(result).to.be.a('string')
+      expect(result).contains('"rootfolder__message"')
+      expect(result).contains(`data-type="${res}"`)
+    })
+  })
+
+  test(`Other results render default message`, () => {
+    const result = rootFolderMessage('ok', CONFIG_DEPTH)
+
+    expect(result).to.be.a('string')
+    expect(result).contains('"rootfolder__message rootfolder__message--default"')
+    expect(result).contains(`data-type="ok"`)
+  })
+})

--- a/src/test/suite/templates/workspace/views/invalidView.test.ts
+++ b/src/test/suite/templates/workspace/views/invalidView.test.ts
@@ -32,8 +32,8 @@ suite('Templates > Workspace > View: invalidView()', () => {
     sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
   })
 
-  test('Renders an no-root-folders error', () => {
-    const result = invalidView(
+  test.skip('Renders an no-root-folders error', () => {
+    /*     const result = invalidView(
       getMockState({ result: 'no-root-folders' }),
       getMockRenderVars({ depth: 1 })
     )
@@ -42,22 +42,22 @@ suite('Templates > Workspace > View: invalidView()', () => {
       "No root folders specified. Please edit the config option 'workspaceSidebar.rootFolders'"
     )
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'ROOT_FOLDERS')
+    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'ROOT_FOLDERS') */
   })
 
-  test('Renders an invalid-folder error', () => {
-    const result = invalidView(
+  test.skip('Renders an invalid-folder error', () => {
+    /*     const result = invalidView(
       getMockState({ result: 'invalid-folder' }),
       getMockRenderVars({ depth: 1 })
     )
 
     expect(result).contains('None of the root folders are directories')
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
+    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
   })
 
-  test('Renders a no-workspaces error', () => {
-    const result = invalidView(
+  test.skip('Renders a no-workspaces error', () => {
+    /*     const result = invalidView(
       getMockState({ result: 'no-workspaces' }),
       getMockRenderVars({ depth: 1 })
     )
@@ -68,11 +68,11 @@ suite('Templates > Workspace > View: invalidView()', () => {
       'The current search depth is 0, this means that only the root folders will be searched in for workspace files.'
     )
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
+    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
   })
 
-  test('Renders a no-workspaces error (zero depth)', () => {
-    const result = invalidView(
+  test.skip('Renders a no-workspaces error (zero depth)', () => {
+    /*     const result = invalidView(
       getMockState({ result: 'no-workspaces' }),
       getMockRenderVars({ depth: 0 })
     )
@@ -83,14 +83,14 @@ suite('Templates > Workspace > View: invalidView()', () => {
       'The current search depth is 0, this means that only the root folders will be searched in for workspace files.'
     )
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
+    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
   })
 
-  test('Renders an generic error in other cases', () => {
-    const result = invalidView(getMockState({ result: 'ok' }), getMockRenderVars({ depth: 1 }))
+  test.skip('Renders an generic error in other cases', () => {
+    /*     const result = invalidView(getMockState({ result: 'ok' }), getMockRenderVars({ depth: 1 }))
 
     expect(result).contains('Something went wrong whilst collecting workspaces')
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
+    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
   })
 })

--- a/src/test/suite/templates/workspace/views/invalidView.test.ts
+++ b/src/test/suite/templates/workspace/views/invalidView.test.ts
@@ -1,23 +1,22 @@
 import { expect } from 'chai'
-import * as sinon from 'sinon'
-import * as links from '../../../../../templates/common/snippets/viewLink'
 import { invalidView } from '../../../../../templates/workspace/views/invalidView'
+import { FindFileResult } from '../../../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { getMockRenderVars } from '../../../../mocks/mockRenderVars'
-import { getMockState } from '../../../../mocks/mockState'
+import { getMockRootFolders, getMockState } from '../../../../mocks/mockState'
 
 suite('Templates > Workspace > View: invalidView()', () => {
-  let vlSpy: sinon.SinonSpy
-
-  setup(() => {
-    vlSpy = sinon.spy(links, 'viewLink')
-  })
-
-  teardown(() => {
-    vlSpy.restore()
-  })
+  const results: FindFileResult[] = [
+    'is-file',
+    'is-hidden-excluded',
+    'no-root-folders',
+    'no-workspaces',
+    'nonexistent',
+    'ok',
+  ]
+  const mockRenderVars = getMockRenderVars()
 
   test('Renders the base view', () => {
-    const result = invalidView(getMockState(), getMockRenderVars())
+    const result = invalidView(getMockState(), mockRenderVars)
 
     expect(result).to.be.a('string')
     expect(result).contains('class="view invalid"')
@@ -25,72 +24,35 @@ suite('Templates > Workspace > View: invalidView()', () => {
     expect(result).contains('<span class="view__message-icon codicon codicon-error"></span>')
   })
 
-  test('Renders a settings link', () => {
-    invalidView(getMockState(), getMockRenderVars())
+  results.forEach((res) => {
+    test(`"${res}" renders as expected`, () => {
+      const result = invalidView(getMockState({ result: res }), mockRenderVars)
 
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS')
+      expect(result).contains(`data-type="${res}"`)
+      expect(result).contains('view__message-title')
+      expect(result).contains('view__message-description')
+    })
   })
 
-  test.skip('Renders an no-root-folders error', () => {
-    /*     const result = invalidView(
-      getMockState({ result: 'no-root-folders' }),
-      getMockRenderVars({ depth: 1 })
-    )
+  test('"no-workspaces" description count is 2 if depth is 0', () => {
+    const mockRootFolders = getMockRootFolders()
+    const regex = /view__message-description/g
+    const state = getMockState({ ...mockRootFolders, result: 'no-workspaces' })
 
-    expect(result).contains(
-      "No root folders specified. Please edit the config option 'workspaceSidebar.rootFolders'"
-    )
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'ROOT_FOLDERS') */
+    state.workspaceData[0].depth = 0
+
+    const count = (invalidView(state, mockRenderVars).match(regex) || []).length
+    expect(count).to.equal(2)
   })
 
-  test.skip('Renders an invalid-folder error', () => {
-    /*     const result = invalidView(
-      getMockState({ result: 'invalid-folder' }),
-      getMockRenderVars({ depth: 1 })
-    )
+  test('"no-workspaces" description count is 1 if depth is >= 1', () => {
+    const mockRootFolders = getMockRootFolders()
+    const regex = /view__message-description/g
+    const state = getMockState({ ...mockRootFolders, result: 'no-workspaces' })
 
-    expect(result).contains('None of the root folders are directories')
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
-  })
+    state.workspaceData[0].depth = 1
 
-  test.skip('Renders a no-workspaces error', () => {
-    /*     const result = invalidView(
-      getMockState({ result: 'no-workspaces' }),
-      getMockRenderVars({ depth: 1 })
-    )
-
-    expect(result).contains('Folders contain no workspaces')
-    expect(result).contains('Try increasing the search depth or change the folders.')
-    expect(result).not.contains(
-      'The current search depth is 0, this means that only the root folders will be searched in for workspace files.'
-    )
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
-  })
-
-  test.skip('Renders a no-workspaces error (zero depth)', () => {
-    /*     const result = invalidView(
-      getMockState({ result: 'no-workspaces' }),
-      getMockRenderVars({ depth: 0 })
-    )
-
-    expect(result).contains('Folders contain no workspaces')
-    expect(result).contains('Try increasing the search depth or change the folders.')
-    expect(result).contains(
-      'The current search depth is 0, this means that only the root folders will be searched in for workspace files.'
-    )
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
-  })
-
-  test.skip('Renders an generic error in other cases', () => {
-    /*     const result = invalidView(getMockState({ result: 'ok' }), getMockRenderVars({ depth: 1 }))
-
-    expect(result).contains('Something went wrong whilst collecting workspaces')
-    sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'Check extension settings', 'SETTINGS') */
+    const count = (invalidView(state, mockRenderVars).match(regex) || []).length
+    expect(count).to.equal(1)
   })
 })

--- a/src/test/suite/templates/workspace/views/loadingView.test.ts
+++ b/src/test/suite/templates/workspace/views/loadingView.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import * as sinon from 'sinon'
+import * as folders from '../../../../../config/folders'
 import * as links from '../../../../../templates/common/snippets/viewLink'
 import { loadingView } from '../../../../../templates/workspace/views/loadingView'
 import { getMockRenderVars } from '../../../../mocks/mockRenderVars'
@@ -7,16 +8,21 @@ import { getMockState } from '../../../../mocks/mockState'
 
 suite('Templates > Workspace > View: loadingView()', () => {
   let vlSpy: sinon.SinonSpy
+  let excludedHiddenConfigStub: sinon.SinonStub
 
   setup(() => {
+    excludedHiddenConfigStub = sinon
+      .stub(folders, 'getExcludeHiddenFoldersConfig')
+      .callsFake(() => true)
     vlSpy = sinon.spy(links, 'viewLink')
   })
 
   teardown(() => {
     vlSpy.restore()
+    excludedHiddenConfigStub.restore()
   })
 
-  test('Renders as expected', () => {
+  test('Renders common content', () => {
     const result = loadingView(getMockState(), getMockRenderVars())
 
     expect(result).to.be.a('string')
@@ -26,9 +32,26 @@ suite('Templates > Workspace > View: loadingView()', () => {
       '<span class="view__message-icon codicon codicon-loading codicon-modifier-spin"></span>'
     )
     expect(result).contains('Collecting workspaces...')
-    expect(result).contains('If this is taking a long time, try and ')
+  })
+
+  test('Renders as expected if excluding hidden folders.', () => {
+    excludedHiddenConfigStub.callsFake(() => true)
+    const result = loadingView(getMockState(), getMockRenderVars())
+
+    expect(result).to.be.a('string')
+    expect(result).contains('If this is taking a long time, try and exclude')
 
     sinon.assert.callCount(vlSpy, 1)
-    sinon.assert.calledWith(vlSpy, 'exclude folders', 'EXCLUDE_FOLDERS')
+  })
+
+  test('Renders as expected if including hidden folders.', () => {
+    excludedHiddenConfigStub.callsFake(() => false)
+    const result = loadingView(getMockState(), getMockRenderVars())
+
+    expect(result).to.be.a('string')
+    expect(result).contains('If this is taking a long time, try and exclude')
+    expect(result).contains(' or ')
+
+    sinon.assert.callCount(vlSpy, 3)
   })
 })

--- a/src/test/suite/utils/fs/collectFilesFromFolder.test.ts
+++ b/src/test/suite/utils/fs/collectFilesFromFolder.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import mockFs from 'mock-fs'
+import * as path from 'path'
 import { collectFilesFromFolder } from '../../../../utils/fs/collectFilesFromFolder'
 import { mockFsStructure } from '../../../mocks/mockFsStructure'
 
@@ -66,7 +67,7 @@ suite('Utils > Fs > collectFilesFromFolder()', () => {
       excludedFolders: [],
       excludeHiddenFolders: true,
       fileType: FILE_TYPE,
-      folder: `/temp/.${FOLDER}`,
+      folder: path.join('temp', `.${FOLDER}`),
       maxDepth: MAX_DEPTH,
     })
 

--- a/src/test/suite/utils/fs/findRootFolderFiles.test.ts
+++ b/src/test/suite/utils/fs/findRootFolderFiles.test.ts
@@ -1,7 +1,10 @@
 import { expect } from 'chai'
 import mockFs from 'mock-fs'
 import * as path from 'path'
-import { findRootFolderFiles } from '../../../../utils/fs/findRootFolderFiles'
+import {
+  FindRootFolderFilesConfig,
+  findRootFolderFiles,
+} from '../../../../utils/fs/findRootFolderFiles'
 import { OS_HOMEFOLDER } from '../../../mocks/mockFileData'
 import { mockFsStructure } from '../../../mocks/mockFsStructure'
 
@@ -16,50 +19,131 @@ suite('Utils > Fs > findRootFolderFiles()', () => {
     mockFs.restore()
   })
 
-  test('invalid-folder object is returned if the folder is not a folder', () => {
-    return findRootFolderFiles({
+  const getConfig = (testConfig: Partial<FindRootFolderFilesConfig>): FindRootFolderFilesConfig => {
+    return {
       excludedFolders: [],
       excludeHiddenFolders: true,
-      folder: 'a.file',
+      folder: '',
       homeDir: OS_HOMEFOLDER,
       maxDepth: 1,
-    }).then((wsFiles) => {
-      expect(wsFiles).to.eql({ files: [], folderPath: 'a.file', result: 'invalid-folder' })
+      ...testConfig,
+    }
+  }
+
+  test('If the folder does not exist, "nonexistent" is returned', () => {
+    const testPath = path.join('nonexistent', 'folder')
+    const config = getConfig({ folder: testPath })
+
+    return findRootFolderFiles(config).then((wsFiles) => {
+      expect(wsFiles).to.eql({
+        depth: 1,
+        files: [],
+        folderPath: testPath,
+        result: 'nonexistent',
+      })
     })
   })
 
-  test('no-workspaces object is returned if the folder contains no workspace files', () => {
-    return findRootFolderFiles({
-      excludedFolders: [],
-      excludeHiddenFolders: true,
-      folder: 'get-filenames-of-type',
-      homeDir: OS_HOMEFOLDER,
-      maxDepth: 1,
-    }).then((wsFiles) => {
+  test('If the folder is a file, "is-file" is returned', () => {
+    const testPath = path.join('check-file', 'test-file.txt')
+    const config = getConfig({ folder: testPath })
+
+    return findRootFolderFiles(config).then((wsFiles) => {
       expect(wsFiles).to.eql({
+        depth: 1,
         files: [],
-        folderPath: 'get-filenames-of-type',
+        folderPath: testPath,
+        result: 'is-file',
+      })
+    })
+  })
+
+  test('If no workspaces are found, "no-workspaces" is returned', () => {
+    const testPath = path.join('get-filenames-of-type')
+    const config = getConfig({ folder: testPath })
+
+    return findRootFolderFiles(config).then((wsFiles) => {
+      expect(wsFiles).to.eql({
+        depth: 1,
+        files: [],
+        folderPath: testPath,
         result: 'no-workspaces',
       })
     })
   })
 
-  test('valid object is returned if the folder contains files of correct type', () => {
-    return findRootFolderFiles({
-      excludedFolders: [],
-      excludeHiddenFolders: true,
-      folder: FOLDER,
-      homeDir: OS_HOMEFOLDER,
-      maxDepth: 1,
-    }).then((wsFiles) => {
+  test('If workspaces are found, "ok" is returned', () => {
+    const testPath = path.join(FOLDER)
+    const config = getConfig({ folder: testPath })
+
+    return findRootFolderFiles(config).then((wsFiles) => {
       expect(wsFiles).to.eql({
+        depth: 1,
         files: [
-          path.join(FOLDER, 'WS 0.code-workspace'),
-          path.join(FOLDER, 'test-subfolder1', 'WS 1.code-workspace'),
-          path.join(FOLDER, 'test-subfolder2', 'WS 2.code-workspace'),
+          path.join(testPath, 'WS 0.code-workspace'),
+          path.join(testPath, 'test-subfolder1', 'WS 1.code-workspace'),
+          path.join(testPath, 'test-subfolder2', 'WS 2.code-workspace'),
         ],
         folderPath: 'find-workspace-files',
         result: 'ok',
+      })
+    })
+  })
+
+  suite('Hidden Folders', () => {
+    test('If a subfolder is hidden and exclude hidden is true, "is-hidden-excluded" is returned', () => {
+      const testPath = path.join('hideme', '.hiddenfolder')
+      const config = getConfig({ excludeHiddenFolders: true, folder: testPath })
+
+      return findRootFolderFiles(config).then((wsFiles) => {
+        expect(wsFiles).to.eql({
+          depth: 1,
+          files: [],
+          folderPath: testPath,
+          result: 'is-hidden-excluded',
+        })
+      })
+    })
+
+    test('If a subfolder is hidden and exclude hidden is false, "ok" is returned', () => {
+      const testPath = path.join('hideme', '.hiddenfolder')
+      const config = getConfig({ excludeHiddenFolders: false, folder: testPath })
+
+      return findRootFolderFiles(config).then((wsFiles) => {
+        expect(wsFiles).to.eql({
+          depth: 1,
+          files: [path.join('hideme', '.hiddenfolder', 'hiddenfolder.code-workspace')],
+          folderPath: testPath,
+          result: 'ok',
+        })
+      })
+    })
+
+    test('If the first folder is hidden and exclude hidden is true, "is-hidden-excluded" is returned', () => {
+      const testPath = path.join('.hiddenfolder')
+      const config = getConfig({ excludeHiddenFolders: true, folder: testPath })
+
+      return findRootFolderFiles(config).then((wsFiles) => {
+        expect(wsFiles).to.eql({
+          depth: 1,
+          files: [],
+          folderPath: testPath,
+          result: 'is-hidden-excluded',
+        })
+      })
+    })
+
+    test('If the first folder is hidden and exclude hidden is false, "ok" is returned', () => {
+      const testPath = path.join('.hiddenfolder')
+      const config = getConfig({ excludeHiddenFolders: false, folder: testPath })
+
+      return findRootFolderFiles(config).then((wsFiles) => {
+        expect(wsFiles).to.eql({
+          depth: 1,
+          files: [path.join('.hiddenfolder', 'hiddenfolder.code-workspace')],
+          folderPath: testPath,
+          result: 'ok',
+        })
       })
     })
   })

--- a/src/test/suite/utils/numbers/getIntWithinBounds.test.ts
+++ b/src/test/suite/utils/numbers/getIntWithinBounds.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai'
+import { getIntWithinBounds } from '../../../../utils/numbers/getIntWithinBounds'
+
+suite('Utils > Numbers > getIntWithinBounds()', () => {
+  const min = 0
+  const max = 10
+
+  test('Returns num if within bounds', () => {
+    expect(getIntWithinBounds(min, min, max)).to.equal(0)
+    expect(getIntWithinBounds(5, min, max)).to.equal(5)
+    expect(getIntWithinBounds(max, min, max)).to.equal(max)
+  })
+
+  test('Returns min, if num less than min', () => {
+    expect(getIntWithinBounds(-2, min, max)).to.equal(min)
+  })
+
+  test('Returns max, if num greater than max', () => {
+    expect(getIntWithinBounds(12, min, max)).to.equal(max)
+  })
+})

--- a/src/test/suite/webviews/Workspace/helpers/getFileTree.test.ts
+++ b/src/test/suite/webviews/Workspace/helpers/getFileTree.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import * as compact from '../../../../../webviews/Workspace/helpers/compactTree'
 import * as condense from '../../../../../webviews/Workspace/helpers/condenseTree'
 import { getFileTree } from '../../../../../webviews/Workspace/helpers/getFileTree'
@@ -31,7 +32,7 @@ suite('Webviews > Workspace > Helpers > getFileTree():', () => {
     condenseSpy = sinon.spy(condense, 'condenseTree')
     folderConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_USERPATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_USERPATH, depth: CONFIG_DEPTH }])
     osHomeStub = sinon.stub(os, 'homedir').callsFake(() => OS_HOMEFOLDER)
   })
 

--- a/src/test/suite/webviews/Workspace/helpers/getNewRootFolderConfig.test.ts
+++ b/src/test/suite/webviews/Workspace/helpers/getNewRootFolderConfig.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path'
 import * as sinon from 'sinon'
 import * as vscode from 'vscode'
 import * as foldersConfigs from '../../../../../config/folders'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { isWindows } from '../../../../../utils/os/isWindows'
 import { getNewRootFolderConfig } from '../../../../../webviews/Workspace/helpers/getNewRootFolderConfig'
 import { OS_HOMEFOLDER, OS_HOMEFOLDER_WIN } from '../../../../mocks/mockFileData'
@@ -18,7 +19,11 @@ suite('Config > Helpers > getNewRootFolderConfig():', function () {
     return `${path.sep}${path.join(OS_HOMEFOLDER, folder)}`
   }
 
-  const defaultPaths = [getPath('Dev'), getPath('Public'), getPath('Temp')]
+  const defaultPaths = [
+    { path: getPath('Dev'), depth: CONFIG_DEPTH },
+    { path: getPath('Public'), depth: CONFIG_DEPTH },
+    { path: getPath('Temp'), depth: CONFIG_DEPTH },
+  ]
 
   let foldersConfigStub: sinon.SinonStub
 

--- a/src/test/suite/webviews/Workspace/helpers/getNewRootFolderConfig.test.ts
+++ b/src/test/suite/webviews/Workspace/helpers/getNewRootFolderConfig.test.ts
@@ -46,7 +46,7 @@ suite('Config > Helpers > getNewRootFolderConfig():', function () {
     ])
 
     expect(result).to.eql([
-      isWin ? filePath.charAt(0).toLowerCase() + filePath.slice(1) : filePath,
+      { path: isWin ? filePath.charAt(0).toLowerCase() + filePath.slice(1) : filePath },
       ...defaultPaths,
     ])
   })

--- a/src/test/suite/webviews/Workspace/store/error.test.ts
+++ b/src/test/suite/webviews/Workspace/store/error.test.ts
@@ -6,16 +6,16 @@ suite('Webviews > Workspace > Store > error()', () => {
   test('Updates state as expected', () => {
     const state = getMockState({
       error: '',
-      result: 'invalid-folder',
-      isFolderInvalid: true,
+      result: 'is-file',
       view: 'invalid',
+      workspaceData: [],
     })
     const expectedState = getMockState({
       error: 'DEFAULT',
       errorObj: { message: 'some error' },
       result: 'ok',
-      isFolderInvalid: false,
       view: 'error',
+      workspaceData: [],
     })
 
     expect(state).not.to.eql(expectedState)

--- a/src/test/suite/webviews/Workspace/store/fetch.test.ts
+++ b/src/test/suite/webviews/Workspace/store/fetch.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { FindAllRootFolderFiles } from '../../../../../utils/fs/findAllRootFolderFiles'
 import {
   ActionMetaFulfilled,
@@ -35,7 +36,7 @@ suite('Webviews > Workspace > Store > fetch()', () => {
     osStub = sinon.stub(os, 'homedir').callsFake(() => OS_HOMEFOLDER)
     rootFoldersConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_PATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_PATH, depth: CONFIG_DEPTH }])
     treeConfigStub = sinon.stub(treeConfigs, 'getShowTreeConfig').callsFake(() => false)
   })
 
@@ -49,13 +50,11 @@ suite('Webviews > Workspace > Store > fetch()', () => {
 
   test('Pending updates state as expected', () => {
     const state = getMockState({
-      result: 'invalid-folder',
-      isFolderInvalid: true,
+      result: 'is-file',
       view: 'invalid',
     })
     const expectedState = getMockState({
       result: 'ok',
-      isFolderInvalid: false,
       view: 'loading',
     })
 
@@ -100,12 +99,10 @@ suite('Webviews > Workspace > Store > fetch()', () => {
 
     const intialState: Partial<WorkspaceState> = {
       result: 'ok',
-      isFolderInvalid: false,
       view: 'loading',
     }
     const defaultExpectedState: Partial<WorkspaceState> = {
       fileCount: 0,
-      isFolderInvalid: true,
       rootFolders: [],
       view: 'invalid',
       visibleFileCount: 0,
@@ -115,7 +112,7 @@ suite('Webviews > Workspace > Store > fetch()', () => {
       condenseConfigStub.callsFake(() => false)
       treeConfigStub.callsFake(() => true)
 
-      const result = 'invalid-folder'
+      const result = 'is-file'
       const state = getMockState(intialState)
       const expectedState = getMockState({
         ...defaultExpectedState,
@@ -172,13 +169,11 @@ suite('Webviews > Workspace > Store > fetch()', () => {
     }
 
     const intialState: Partial<WorkspaceState> = {
-      isFolderInvalid: true,
       rootFolders: [],
       view: 'invalid',
     }
     const defaultExpectedState: Partial<WorkspaceState> = {
       result: 'ok',
-      isFolderInvalid: false,
       view: 'list',
     }
 

--- a/src/test/suite/webviews/Workspace/store/fetch.test.ts
+++ b/src/test/suite/webviews/Workspace/store/fetch.test.ts
@@ -178,7 +178,7 @@ suite('Webviews > Workspace > Store > fetch()', () => {
     }
 
     suite('List:', () => {
-      test('Sort "asc" updates state as expected', () => {
+      test('Updates state as expected', () => {
         const mockRootFolders = getMockRootFolders({
           showTree: false,
         })
@@ -186,24 +186,6 @@ suite('Webviews > Workspace > Store > fetch()', () => {
         const expectedState = getMockState({
           ...defaultExpectedState,
           ...mockRootFolders,
-        })
-
-        expect(state).not.to.eql(expectedState)
-        fetchFulfilled(state, getAction(mockRootFolders.rootFolders))
-        expect(state).to.eql(expectedState)
-      })
-
-      test('Sort "asc" searched updates state as expected', () => {
-        const mockRootFolders = getMockRootFolders({
-          searchTerm: SEARCH_TERM,
-          showTree: false,
-        })
-        const search = getMockSearchState({ term: SEARCH_TERM })
-        const state = getMockState({ ...intialState, search })
-        const expectedState = getMockState({
-          ...defaultExpectedState,
-          ...mockRootFolders,
-          search,
         })
 
         expect(state).not.to.eql(expectedState)

--- a/src/test/suite/webviews/Workspace/store/invalid.test.ts
+++ b/src/test/suite/webviews/Workspace/store/invalid.test.ts
@@ -5,12 +5,12 @@ import { getMockState } from '../../../../mocks/mockState'
 suite('Webviews > Workspace > Store > invalid()', () => {
   test('Updates state as expected', () => {
     const state = getMockState({
-      isFolderInvalid: false,
       view: 'error',
+      workspaceData: [],
     })
     const expectedState = getMockState({
-      isFolderInvalid: true,
       view: 'invalid',
+      workspaceData: [],
     })
 
     expect(state).not.to.eql(expectedState)

--- a/src/test/suite/webviews/Workspace/store/list.test.ts
+++ b/src/test/suite/webviews/Workspace/store/list.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { FindAllRootFolderFiles } from '../../../../../utils/fs/findAllRootFolderFiles'
 import {
   ActionMetaFulfilled,
@@ -30,7 +31,7 @@ suite('Webviews > Workspace > Store > list()', () => {
     osStub = sinon.stub(os, 'homedir').callsFake(() => OS_HOMEFOLDER)
     rootFoldersConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_PATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_PATH, depth: CONFIG_DEPTH }])
     treeConfigStub = sinon.stub(treeConfigs, 'getShowTreeConfig').callsFake(() => false)
   })
 
@@ -53,13 +54,11 @@ suite('Webviews > Workspace > Store > list()', () => {
   }
 
   const intialState: Partial<WorkspaceState> = {
-    isFolderInvalid: true,
     rootFolders: [],
     view: 'invalid',
   }
   const defaultExpectedState: Partial<WorkspaceState> = {
     result: 'ok',
-    isFolderInvalid: false,
     view: 'list',
   }
 

--- a/src/test/suite/webviews/Workspace/store/loading.test.ts
+++ b/src/test/suite/webviews/Workspace/store/loading.test.ts
@@ -9,22 +9,22 @@ suite('Webviews > Workspace > Store > loading()', () => {
       errorObj: null,
       fileCount: 0,
       result: 'ok',
-      isFolderInvalid: true,
       rootFolders: [],
       selected: 'sdasd',
       view: 'loading',
       visibleFileCount: 0,
+      workspaceData: [],
     })
     const expectedState = getMockState({
       error: '',
       errorObj: null,
       fileCount: 0,
       result: 'ok',
-      isFolderInvalid: false,
       rootFolders: [],
       selected: '',
       view: 'loading',
       visibleFileCount: 0,
+      workspaceData: [],
     })
 
     expect(state).not.to.eql(expectedState)

--- a/src/test/suite/webviews/Workspace/store/setFileTree.test.ts
+++ b/src/test/suite/webviews/Workspace/store/setFileTree.test.ts
@@ -4,6 +4,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { setFileTree } from '../../../../../webviews/Workspace/store/setFileTree'
 import { OS_HOMEFOLDER, ROOT_FOLDER_PATH } from '../../../../mocks/mockFileData'
 import { getMockRootFolders, getMockState } from '../../../../mocks/mockState'
@@ -21,7 +22,7 @@ suite('Webviews > Workspace > Store > setFileTree()', () => {
     condenseConfigStub = sinon.stub(treeConfigs, 'getCondenseFileTreeConfig').callsFake(() => true)
     folderConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_PATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_PATH, depth: CONFIG_DEPTH }])
     osStub = sinon.stub(os, 'homedir').callsFake(() => OS_HOMEFOLDER)
   })
 

--- a/src/test/suite/webviews/Workspace/store/setSearch.test.ts
+++ b/src/test/suite/webviews/Workspace/store/setSearch.test.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { setSearch } from '../../../../../webviews/Workspace/store/setSearch'
 import { ROOT_FOLDER_PATH, SEARCH_TERM } from '../../../../mocks/mockFileData'
 import { getMockRootFolders, getMockSearchState, getMockState } from '../../../../mocks/mockState'
@@ -20,7 +21,7 @@ suite('Webviews > Workspace > Store > setSearch()', () => {
     condenseConfigStub = sinon.stub(treeConfigs, 'getCondenseFileTreeConfig').callsFake(() => true)
     folderConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_PATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_PATH, depth: CONFIG_DEPTH }])
     treeConfigStub = sinon.stub(treeConfigs, 'getShowTreeConfig').callsFake(() => false)
   })
 

--- a/src/test/suite/webviews/Workspace/store/setVisibleFiles.test.ts
+++ b/src/test/suite/webviews/Workspace/store/setVisibleFiles.test.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon'
 import * as coreConfigs from '../../../../../config/core'
 import * as foldersConfigs from '../../../../../config/folders'
 import * as treeConfigs from '../../../../../config/treeview'
+import { CONFIG_DEPTH } from '../../../../../constants/config'
 import { setVisibleFiles } from '../../../../../webviews/Workspace/store/setVisibleFiles'
 import { ROOT_FOLDER_PATH } from '../../../../mocks/mockFileData'
 import { getMockRootFolders, getMockState } from '../../../../mocks/mockState'
@@ -20,7 +21,7 @@ suite('Webviews > Workspace > Store > setVisibleFiles()', () => {
     condenseConfigStub = sinon.stub(treeConfigs, 'getCondenseFileTreeConfig').callsFake(() => true)
     folderConfigStub = sinon
       .stub(foldersConfigs, 'getFoldersConfig')
-      .callsFake(() => [ROOT_FOLDER_PATH])
+      .callsFake(() => [{ path: ROOT_FOLDER_PATH, depth: CONFIG_DEPTH }])
     treeConfigStub = sinon.stub(treeConfigs, 'getShowTreeConfig').callsFake(() => false)
   })
 

--- a/src/utils/fs/checkFile.ts
+++ b/src/utils/fs/checkFile.ts
@@ -7,9 +7,11 @@ export interface CheckFile {
 
 export const checkFile = (file: string): CheckFile => {
   try {
-    const isFolder = fs.lstatSync(file).isDirectory()
+    const fileStats = fs.statSync(file)
+    const isFolder = fileStats.isDirectory()
+    const isFile = fileStats.isFile()
 
-    return { isFile: !isFolder, isFolder }
+    return { isFile, isFolder }
   } catch (error) {
     return { isFile: false, isFolder: false }
   }

--- a/src/utils/fs/collectFilesFromFolder.ts
+++ b/src/utils/fs/collectFilesFromFolder.ts
@@ -42,7 +42,7 @@ export const collectFilesFromFolder = async ({
 
       const folders = getFilenamesOfType('folders', filenames, folder, fileType)
       let files = getFilenamesOfType('files', filenames, folder, fileType).filter(
-        (file) => !isHiddenFile(file)
+        (file) => (excludeHiddenFolders && !isHiddenFile(file)) || !excludeHiddenFolders
       )
 
       if (folders.length > 0) {

--- a/src/utils/fs/findAllRootFolderFiles.ts
+++ b/src/utils/fs/findAllRootFolderFiles.ts
@@ -54,13 +54,13 @@ export const findAllRootFolderFiles = async (): Promise<FindAllRootFolderFiles> 
     }
 
     if (fileCount.length === configFolders.length) {
-      return Promise.resolve({ rootFolders: [], result: 'is-file' })
+      return Promise.resolve({ rootFolders, result: 'is-file' })
     } else if (noWorkspaceCount.length === configFolders.length) {
-      return Promise.resolve({ rootFolders: [], result: 'no-workspaces' })
+      return Promise.resolve({ rootFolders, result: 'no-workspaces' })
     } else if (isHiddenExcludedCount.length === configFolders.length) {
-      return Promise.resolve({ rootFolders: [], result: 'is-hidden-excluded' })
+      return Promise.resolve({ rootFolders, result: 'is-hidden-excluded' })
     } else if (nonExistentCount.length === configFolders.length) {
-      return Promise.resolve({ rootFolders: [], result: 'nonexistent' })
+      return Promise.resolve({ rootFolders, result: 'nonexistent' })
     } // Else, Some root folders are empty or invalid - List view will handle these
 
     return Promise.resolve({ rootFolders, result: 'ok' })

--- a/src/utils/fs/findAllRootFolderFiles.ts
+++ b/src/utils/fs/findAllRootFolderFiles.ts
@@ -22,9 +22,10 @@ export const findAllRootFolderFiles = async (): Promise<FindAllRootFolderFiles> 
     const excludeHiddenFoldersConfig = getExcludeHiddenFoldersConfig()
     const homeDir = os.homedir()
 
+    const fileCount: string[] = []
+    const nonExistentCount: string[] = []
+    const noWorkspaceCount: string[] = []
     const rootFolders: FindRootFolderFiles[] = []
-    const invalidFolders: string[] = []
-    const noWorkspaces: string[] = []
 
     for (let index = 0; index < folders.length; index++) {
       const folder = folders[index].trim()
@@ -39,19 +40,23 @@ export const findAllRootFolderFiles = async (): Promise<FindAllRootFolderFiles> 
         })
 
         if (rootFolder.result === 'no-workspaces') {
-          noWorkspaces.push(folder)
-        } else if (rootFolder.result === 'invalid-folder') {
-          invalidFolders.push(folder)
+          noWorkspaceCount.push(folder)
+        } else if (rootFolder.result === 'is-file') {
+          fileCount.push(folder)
+        } else if (rootFolder.result === 'nonexistent') {
+          nonExistentCount.push(folder)
         }
 
         rootFolders.push(rootFolder)
       }
     }
 
-    if (invalidFolders.length === folders.length) {
-      return Promise.resolve({ rootFolders: [], result: 'invalid-folder' })
-    } else if (noWorkspaces.length === folders.length) {
+    if (fileCount.length === folders.length) {
+      return Promise.resolve({ rootFolders: [], result: 'is-file' })
+    } else if (noWorkspaceCount.length === folders.length) {
       return Promise.resolve({ rootFolders: [], result: 'no-workspaces' })
+    } else if (nonExistentCount.length === folders.length) {
+      return Promise.resolve({ rootFolders: [], result: 'nonexistent' })
     } // Else, Some root folders are empty or invalid - List view will handle these
 
     return Promise.resolve({ rootFolders, result: 'ok' })

--- a/src/utils/fs/findRootFolderFiles.ts
+++ b/src/utils/fs/findRootFolderFiles.ts
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import { FS_WS_FILETYPE } from '../../constants/fs'
 import {
   FindFileResult,
@@ -7,6 +8,10 @@ import { checkFile } from './checkFile'
 import { collectFilesFromFolder } from './collectFilesFromFolder'
 
 export interface FindRootFolderFiles {
+  /**
+   * The depth for this root folder.
+   */
+  depth: number
   files: WorkspaceFiles
   /**
    * The folder with ~ replaced with the users homedir
@@ -31,10 +36,20 @@ export const findRootFolderFiles = async ({
   maxDepth,
 }: FindRootFolderFilesConfig): Promise<FindRootFolderFiles> => {
   const folderPath = folder.replace(`~`, homeDir)
-
   const { isFile, isFolder } = checkFile(folderPath)
 
   if (isFolder) {
+    const isHiddenExcluded = excludeHiddenFolders && folderPath.includes(`${path.sep}.`)
+
+    if (isHiddenExcluded) {
+      return Promise.resolve({
+        depth: maxDepth,
+        files: [],
+        folderPath,
+        result: 'is-hidden-excluded',
+      })
+    }
+
     const files = await collectFilesFromFolder({
       curDepth: 0,
       excludedFolders,
@@ -45,12 +60,14 @@ export const findRootFolderFiles = async ({
     })
 
     return Promise.resolve({
+      depth: maxDepth,
       files: files,
       folderPath,
       result: files.length > 0 ? 'ok' : 'no-workspaces',
     })
   } else if (isFile) {
     return Promise.resolve({
+      depth: maxDepth,
       files: [],
       folderPath,
       result: 'is-file',
@@ -58,6 +75,7 @@ export const findRootFolderFiles = async ({
   }
 
   return Promise.resolve({
+    depth: maxDepth,
     files: [],
     folderPath,
     result: 'nonexistent',

--- a/src/utils/fs/findRootFolderFiles.ts
+++ b/src/utils/fs/findRootFolderFiles.ts
@@ -39,7 +39,8 @@ export const findRootFolderFiles = async ({
   const { isFile, isFolder } = checkFile(folderPath)
 
   if (isFolder) {
-    const isHiddenExcluded = excludeHiddenFolders && folderPath.includes(`${path.sep}.`)
+    const isHiddenExcluded =
+      excludeHiddenFolders && (folderPath.includes(`${path.sep}.`) || folderPath.startsWith(`.`))
 
     if (isHiddenExcluded) {
       return Promise.resolve({

--- a/src/utils/fs/findRootFolderFiles.ts
+++ b/src/utils/fs/findRootFolderFiles.ts
@@ -32,7 +32,7 @@ export const findRootFolderFiles = async ({
 }: FindRootFolderFilesConfig): Promise<FindRootFolderFiles> => {
   const folderPath = folder.replace(`~`, homeDir)
 
-  const { isFolder } = checkFile(folderPath)
+  const { isFile, isFolder } = checkFile(folderPath)
 
   if (isFolder) {
     const files = await collectFilesFromFolder({
@@ -49,11 +49,17 @@ export const findRootFolderFiles = async ({
       folderPath,
       result: files.length > 0 ? 'ok' : 'no-workspaces',
     })
+  } else if (isFile) {
+    return Promise.resolve({
+      files: [],
+      folderPath,
+      result: 'is-file',
+    })
   }
 
   return Promise.resolve({
     files: [],
     folderPath,
-    result: 'invalid-folder',
+    result: 'nonexistent',
   })
 }

--- a/src/utils/numbers/getIntWithinBounds.ts
+++ b/src/utils/numbers/getIntWithinBounds.ts
@@ -1,0 +1,7 @@
+import { CONFIG_DEPTH_MAX, CONFIG_DEPTH_MIN } from '../../constants/config'
+
+export const getIntWithinBounds = (
+  num: number,
+  min: number = CONFIG_DEPTH_MIN,
+  max: number = CONFIG_DEPTH_MAX
+): number => Math.min(Math.max(num, min), max)

--- a/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
@@ -13,6 +13,26 @@ export interface File {
 
 export type Files = File[]
 
+/**
+ * Root folder object from settings.json
+ */
+export interface ConfigRootFolderSettings {
+  depth?: number
+  path: string
+}
+
+/**
+ * Root folder object returned by getFoldersConfig()
+ */
+export interface ConfigRootFolder {
+  /**
+   * The depth for this folder, if absent in config or NAN, the default depth (workspaceSidebar.depth) will be used instead.
+   * Also the config depth will be constrained in value to min/max values of workspaceSidebar.depth.
+   */
+  depth: number
+  path: string
+}
+
 export interface WorkspaceSetCacheData {
   folderPath: string
   files: WorkspaceFiles
@@ -43,6 +63,7 @@ export interface WorkspaceRootFolderCache {
 }
 
 export interface WorkspaceCacheRootFolder {
+  depth: number
   folderPath: string
   files: WorkspaceFiles
 }
@@ -51,7 +72,12 @@ export type WorkspaceCacheRootFolders = WorkspaceCacheRootFolder[]
 
 export type WorkspaceErrors = '' | 'DEFAULT' | 'FETCH'
 
-export type ViewLinkType = 'EXCLUDE_FOLDERS' | 'ROOT_FOLDERS' | 'SETTINGS'
+export type ViewLinkType =
+  | 'DEPTH'
+  | 'EXCLUDE_FOLDERS'
+  | 'EXCLUDE_HIDDEN_FOLDERS'
+  | 'ROOT_FOLDERS'
+  | 'SETTINGS'
 
 /**
  * Messages sent by the FE
@@ -91,7 +117,13 @@ export type PayloadToggleFolderState = {
 }
 export type PayloadToggleFolderStateBulk = FolderState
 
-export type FindFileResult = 'is-file' | 'no-root-folders' | 'no-workspaces' | 'nonexistent' | 'ok'
+export type FindFileResult =
+  | 'is-file'
+  | 'is-hidden-excluded'
+  | 'no-root-folders'
+  | 'no-workspaces'
+  | 'nonexistent'
+  | 'ok'
 
 export interface SearchState {
   caseInsensitive: boolean
@@ -143,6 +175,7 @@ export type WorkspaceStateRootFolder = {
    * The files, converted to a form useable by this extension.
    */
   convertedFiles: Files
+  depth: number
   /**
    * An array of absolute file paths to all workspace files.
    */

--- a/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
@@ -1,4 +1,5 @@
 import { PayloadAction, SerializedError } from '@reduxjs/toolkit'
+import { FindRootFolderFiles } from '../../utils/fs/findRootFolderFiles'
 import { FileTree } from './helpers/getFileTree'
 
 export interface File {
@@ -140,7 +141,6 @@ export type WorkspaceState = {
    * The total number of workspace files for all root folders.
    */
   fileCount: number
-  isFolderInvalid: boolean
   /**
    * The result of the file collection for all root folders.
    */
@@ -156,6 +156,10 @@ export type WorkspaceState = {
    * The total number of visible workspace files for all root folders.
    */
   visibleFileCount: number
+  /**
+   * The results as returned from findAllRootFolderFiles()
+   */
+  workspaceData: FindRootFolderFiles[]
   /**
    * The type of workspace that is currently open.
    */

--- a/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.interface.ts
@@ -24,12 +24,12 @@ export interface WorkspaceRootFolderMachineCache {
    */
   appRoot: string
   /**
-   * VSCode Env remote name. Now that rootFolders config is machine scoped, we need different caches.
-   */
-  /**
-   * The hash for the version, remoteName, and appRoot. Used as a key to identify caches for a particular machine.
+   * The hash for the remoteName, and appRoot. Used as a key to identify caches for a particular machine.
    */
   cacheId: string
+  /**
+   * VSCode Env remote name. Now that rootFolders config is machine scoped, we need different caches.
+   */
   remoteName: string
   rootFolders: WorkspaceCacheRootFolder[]
   /**
@@ -91,7 +91,7 @@ export type PayloadToggleFolderState = {
 }
 export type PayloadToggleFolderStateBulk = FolderState
 
-export type FindFileResult = 'invalid-folder' | 'no-root-folders' | 'no-workspaces' | 'ok'
+export type FindFileResult = 'is-file' | 'no-root-folders' | 'no-workspaces' | 'nonexistent' | 'ok'
 
 export interface SearchState {
   caseInsensitive: boolean

--- a/src/webviews/Workspace/WorkspaceViewProvider.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.ts
@@ -47,7 +47,7 @@ export class WorkspaceViewProvider
   public static readonly viewType = EXT_WEBVIEW_WS
   private _view?: vscode.WebviewView
   private _cssGenerator: CssGenerator
-  private readonly _version: string = '2.0.0-beta-9'
+  private readonly _version: string = '2.0.0-beta-11'
 
   constructor(
     private readonly _ctx: vscode.ExtensionContext,
@@ -193,7 +193,7 @@ export class WorkspaceViewProvider
         crypto.createHash('sha256').update(crypto.randomBytes(16)).digest('hex')
       )
 
-      // Suppress error when running in extension development host
+      // Suppress error when running tests
     } else if (this._ctx.extensionMode !== vscode.ExtensionMode.Test) {
       vscode.window.showErrorMessage(t('errors.viewNotFound'))
     }

--- a/src/webviews/Workspace/WorkspaceViewProvider.ts
+++ b/src/webviews/Workspace/WorkspaceViewProvider.ts
@@ -47,7 +47,7 @@ export class WorkspaceViewProvider
   public static readonly viewType = EXT_WEBVIEW_WS
   private _view?: vscode.WebviewView
   private _cssGenerator: CssGenerator
-  private readonly _version: string = '2.0.0-beta-8'
+  private readonly _version: string = '2.0.0-beta-9'
 
   constructor(
     private readonly _ctx: vscode.ExtensionContext,
@@ -63,15 +63,6 @@ export class WorkspaceViewProvider
       .update(`${vscode.env.appRoot}-${vscode.env.remoteName}`)
       .digest('hex')
   }
-
-  /*   private async deleteCacheAll() {
-    await vscode.commands.executeCommand(CMD_VSC_SET_CTX, EXT_LOADED, false)
-    await this._ctx.globalState.update(EXT_WSSTATE_CACHE, undefined)
-
-    store.dispatch(fetch()).then(() => {
-      this.updateCache(store.getState().ws)
-    })
-  } */
 
   private async deleteCache() {
     let newCacheData: WorkspaceRootFolderCache | undefined
@@ -290,9 +281,12 @@ export class WorkspaceViewProvider
         case Actions.VIEW_LINK:
           if (payload === 'ROOT_FOLDERS') {
             await executeCommand(CMD_VSC_OPEN_SETTINGS, 'workspaceSidebar.rootFolders')
-          }
-          if (payload === 'EXCLUDE_FOLDERS') {
+          } else if (payload === 'DEPTH') {
+            await executeCommand(CMD_VSC_OPEN_SETTINGS, 'workspaceSidebar.depth')
+          } else if (payload === 'EXCLUDE_FOLDERS') {
             await executeCommand(CMD_VSC_OPEN_SETTINGS, 'workspaceSidebar.folders.excluded')
+          } else if (payload === 'EXCLUDE_HIDDEN_FOLDERS') {
+            await executeCommand(CMD_VSC_OPEN_SETTINGS, 'workspaceSidebar.excludeHiddenFolders')
           } else {
             await executeCommand(CMD_VSC_OPEN_SETTINGS, 'workspaceSidebar')
           }
@@ -343,6 +337,7 @@ export class WorkspaceViewProvider
               return [
                 ...allRoots,
                 {
+                  depth: curRoot.depth,
                   folderPath: curRoot.folderPath,
                   files: curRoot.files,
                 },

--- a/src/webviews/Workspace/helpers/getNewRootFolderConfig.ts
+++ b/src/webviews/Workspace/helpers/getNewRootFolderConfig.ts
@@ -1,11 +1,23 @@
 import * as vscode from 'vscode'
 import { getFoldersConfig } from '../../../config/folders'
+import { ConfigRootFolderSettings } from '../WorkspaceViewProvider.interface'
 
-export const getNewRootFolderConfig = (wsFolders: vscode.WorkspaceFolder[]): string[] => {
+export const getNewRootFolderConfig = (
+  wsFolders: vscode.WorkspaceFolder[]
+): ConfigRootFolderSettings[] => {
   const oldConfigFolders = getFoldersConfig()
 
   if (wsFolders.length > 0) {
-    return [...wsFolders.map(({ uri }) => uri.fsPath), ...oldConfigFolders]
+    return [
+      ...wsFolders.map(({ uri }) => {
+        const newFolder: ConfigRootFolderSettings = {
+          path: uri.fsPath,
+        }
+
+        return newFolder
+      }),
+      ...oldConfigFolders,
+    ]
   }
 
   return oldConfigFolders

--- a/src/webviews/Workspace/store/error.ts
+++ b/src/webviews/Workspace/store/error.ts
@@ -11,8 +11,8 @@ export const error = (
   state.errorObj = errorObj
   state.fileCount = 0
   state.result = 'ok'
-  state.isFolderInvalid = false
   state.rootFolders = []
   state.view = 'error'
   state.visibleFileCount = 0
+  state.workspaceData = []
 }

--- a/src/webviews/Workspace/store/fetch.ts
+++ b/src/webviews/Workspace/store/fetch.ts
@@ -42,7 +42,7 @@ export const fetchFulfilled = (
     state.isFolderInvalid = false
     state.view = 'list'
 
-    state.rootFolders = action.payload.rootFolders.map(({ files, folderPath, result }) => {
+    state.rootFolders = action.payload.rootFolders.map(({ depth, files, folderPath, result }) => {
       const folderName = getLastPathSegment(folderPath) || folderPath
       const convertedFiles = convertWsFiles(folderPath, files, state.selected)
       const visibleFiles = getVisibleFiles(convertedFiles, state.search)
@@ -57,6 +57,7 @@ export const fetchFulfilled = (
         allFolders,
         closedFolders: [],
         convertedFiles,
+        depth,
         files,
         fileTree,
         folderName: folderName,

--- a/src/webviews/Workspace/store/fetch.ts
+++ b/src/webviews/Workspace/store/fetch.ts
@@ -5,6 +5,7 @@ import {
   FindAllRootFolderFiles,
   findAllRootFolderFiles,
 } from '../../../utils/fs/findAllRootFolderFiles'
+import { FindRootFolderFiles } from '../../../utils/fs/findRootFolderFiles'
 import { getLastPathSegment } from '../../../utils/fs/getLastPathSegment'
 import {
   ActionMetaFulfilled,
@@ -27,20 +28,21 @@ export const fetchFulfilled = (
   if (action.payload.result !== 'ok') {
     state.fileCount = 0
     state.result = action.payload.result
-    state.isFolderInvalid = true
     state.rootFolders = []
     state.view = 'invalid'
     state.visibleFileCount = 0
+    state.workspaceData = action.payload.rootFolders
   } else {
     const homeDir = os.homedir()
     const showTree = getShowTreeConfig()
 
+    const workspaceData: FindRootFolderFiles[] = []
     let fileCount = 0
     let visibleFileCount = 0
 
     state.result = 'ok'
-    state.isFolderInvalid = false
     state.view = 'list'
+    state.workspaceData = []
 
     state.rootFolders = action.payload.rootFolders.map(({ depth, files, folderPath, result }) => {
       const folderName = getLastPathSegment(folderPath) || folderPath
@@ -52,6 +54,13 @@ export const fetchFulfilled = (
 
       fileCount += files.length
       visibleFileCount += visibleFiles.length
+
+      workspaceData.push({
+        depth,
+        files,
+        folderPath,
+        result,
+      })
 
       return {
         allFolders,
@@ -70,13 +79,14 @@ export const fetchFulfilled = (
 
     state.fileCount = fileCount
     state.visibleFileCount = visibleFileCount
+    state.workspaceData = workspaceData
   }
 }
 
 export const fetchPending = (state: WorkspaceState) => {
   state.view = 'loading'
   state.result = 'ok'
-  state.isFolderInvalid = false
+  state.workspaceData = []
 }
 
 export const fetchRejected = (

--- a/src/webviews/Workspace/store/invalid.ts
+++ b/src/webviews/Workspace/store/invalid.ts
@@ -2,8 +2,8 @@ import { WorkspaceState } from '../WorkspaceViewProvider.interface'
 
 export const invalid = (state: WorkspaceState): void => {
   state.fileCount = 0
-  state.isFolderInvalid = true
   state.rootFolders = []
   state.view = 'invalid'
   state.visibleFileCount = 0
+  state.workspaceData = []
 }

--- a/src/webviews/Workspace/store/list.ts
+++ b/src/webviews/Workspace/store/list.ts
@@ -1,6 +1,7 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 import * as os from 'os'
 import { getShowTreeConfig } from '../../../config/treeview'
+import { FindRootFolderFiles } from '../../../utils/fs/findRootFolderFiles'
 import { getLastPathSegment } from '../../../utils/fs/getLastPathSegment'
 import { WorkspaceCacheRootFolders, WorkspaceState } from '../WorkspaceViewProvider.interface'
 import { convertWsFiles } from '../helpers/convertWsFiles'
@@ -14,6 +15,8 @@ export const list = (
 ): void => {
   const homeDir = os.homedir()
   const showTree = getShowTreeConfig()
+
+  const workspaceData: FindRootFolderFiles[] = []
   let fileCount = 0
   let visibleFileCount = 0
 
@@ -27,6 +30,14 @@ export const list = (
 
     fileCount += files.length
     visibleFileCount += visibleFiles.length
+    const result = files.length < 1 ? 'no-workspaces' : 'ok'
+
+    workspaceData.push({
+      depth,
+      files,
+      folderPath,
+      result,
+    })
 
     return {
       allFolders,
@@ -38,14 +49,14 @@ export const list = (
       folderName: folderName,
       folderPath,
       folderPathShort: folderPath.replace(homeDir, `~`),
-      result: files.length < 1 ? 'no-workspaces' : 'ok',
+      result,
       visibleFiles,
     }
   })
 
   state.result = 'ok'
-  state.isFolderInvalid = false
   state.view = 'list'
   state.fileCount = fileCount
   state.visibleFileCount = visibleFileCount
+  state.workspaceData = workspaceData
 }

--- a/src/webviews/Workspace/store/list.ts
+++ b/src/webviews/Workspace/store/list.ts
@@ -17,7 +17,7 @@ export const list = (
   let fileCount = 0
   let visibleFileCount = 0
 
-  state.rootFolders = action.payload.map(({ files, folderPath }) => {
+  state.rootFolders = action.payload.map(({ depth, files, folderPath }) => {
     const folderName = getLastPathSegment(folderPath) || folderPath
     const convertedFiles = convertWsFiles(folderPath, files, state.selected)
     const visibleFiles = getVisibleFiles(convertedFiles, state.search)
@@ -32,6 +32,7 @@ export const list = (
       allFolders,
       closedFolders: [],
       convertedFiles,
+      depth,
       files,
       fileTree,
       folderName: folderName,

--- a/src/webviews/Workspace/store/loading.ts
+++ b/src/webviews/Workspace/store/loading.ts
@@ -5,9 +5,9 @@ export const loading = (state: WorkspaceState): void => {
   state.errorObj = null
   state.fileCount = 0
   state.result = 'ok'
-  state.isFolderInvalid = false
   state.rootFolders = []
   state.selected = ''
   state.view = 'loading'
   state.visibleFileCount = 0
+  state.workspaceData = []
 }

--- a/src/webviews/Workspace/store/workspaceSlice.ts
+++ b/src/webviews/Workspace/store/workspaceSlice.ts
@@ -24,12 +24,12 @@ export const initialState: WorkspaceState = {
   errorObj: null,
   fileCount: 0,
   result: 'ok',
-  isFolderInvalid: false,
   rootFolders: [],
   search: { ...initialSearchState },
   selected: !!vscode.workspace.workspaceFile ? vscode.workspace.workspaceFile.fsPath : '',
   view: 'loading',
   visibleFileCount: 0,
+  workspaceData: [],
   wsType: getWsType(vscode.workspace.workspaceFile, vscode.workspace.workspaceFolders),
 }
 

--- a/src/webviews/webviews.interface.ts
+++ b/src/webviews/webviews.interface.ts
@@ -26,7 +26,6 @@ export interface RenderVars {
   cleanLabels: boolean
   clickAction: ConfigActions
   condenseFileTree: boolean
-  depth: number
   fileIconKeys: FileIconKeys
   fileIconsActive: boolean
   imgDarkFolderUri: vscode.Uri

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
   "exclude": [
     ".cache",
     ".vscode-test",
-    "test/",
+    "/test",
     "build/",
     "dist/",
     "node_modules/",


### PR DESCRIPTION
Closes #102 

# Summary of Changes

- Adds messages for all states for invalid view and list root folder error messages
- Added depth for each root folder that can override the depth setting on a per folder basis
- Updatd translations
