### PR TITLE
feat(search): ignore closed folders

### DIFF
--- a/src/templates/workspace/snippets/itemFolder.ts
+++ b/src/templates/workspace/snippets/itemFolder.ts
@@ -35,7 +35,7 @@ export const itemFolder = ({
 
   let folderClasses = `list__branch-list-item list__branch-list-item-folder list__styled-item`
 
-  if (isClosable) {
+  if (isClosable && !state.search.term) {
     folderClasses += ' list__branch-list-item-folder--closable'
   }
 

--- a/src/templates/workspace/snippets/list.ts
+++ b/src/templates/workspace/snippets/list.ts
@@ -45,7 +45,8 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
             const isFileTree = showTree && fileTree !== null
             const isRootPathError = rootPathErrors.includes(result)
             const classes = getListClasses(isFileTree)
-            const isClosed = closedFolders.includes(folderName)
+            const isClosed = !search.term && closedFolders.includes(folderName)
+
             const rootFolderFile: FileTree = {
               compactedFolders: [],
               files: [],
@@ -78,7 +79,13 @@ export const list = (state: WorkspaceState, renderVars: RenderVars): string => {
                     ? `<ul class="${classes}">
                           ${
                             isFileTree
-                              ? tree(fileTree, 0, rootFolder.closedFolders, state, renderVars)
+                              ? tree({
+                                  branch: fileTree,
+                                  closedFolders: rootFolder.closedFolders,
+                                  depth: 0,
+                                  renderVars,
+                                  state,
+                                })
                               : ''
                           }
                           ${

--- a/src/templates/workspace/snippets/tree.ts
+++ b/src/templates/workspace/snippets/tree.ts
@@ -8,15 +8,17 @@ import { sortTreeChildren, TreeChildren } from '../../helpers/sortTreeChildren'
 import { itemFile } from './itemFile'
 import { itemFolder } from './itemFolder'
 
-export const tree = (
-  branch: FileTree,
-  depth: number,
-  closedFolders: string[],
-  state: WorkspaceState,
+export type TreeProps = {
+  branch: FileTree
+  closedFolders: string[]
+  depth: number
   renderVars: RenderVars
-): string => {
+  state: WorkspaceState
+}
+
+export const tree = ({ branch, closedFolders, depth, renderVars, state }: TreeProps): string => {
   const { files, folderPathSegment, isRoot, sub } = branch
-  const isClosed = closedFolders.includes(folderPathSegment)
+  const isClosed = !state.search.term && closedFolders.includes(folderPathSegment)
 
   let children: TreeChildren = []
   let fileDepth = depth
@@ -37,7 +39,7 @@ export const tree = (
         if (isFile(child)) {
           return itemFile({ depth: fileDepth, file: child, renderVars, state })
         } else {
-          return tree(child, treeDepth, closedFolders, state, renderVars)
+          return tree({ branch: child, depth: treeDepth, closedFolders, state, renderVars })
         }
       })
       .join('')}

--- a/src/test/suite/templates/workspace/snippets/tree.test.ts
+++ b/src/test/suite/templates/workspace/snippets/tree.test.ts
@@ -79,7 +79,7 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    const result = tree(emptySubTree, 0, [], state, renderVars)
+    const result = tree({ branch: emptySubTree, depth: 0, closedFolders: [], state, renderVars })
 
     expect(result).to.be.a('string')
     expect(result).to.be.empty
@@ -95,7 +95,13 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    const result = tree(closedSubTree, 0, [FOLDER1], state, renderVars)
+    const result = tree({
+      branch: closedSubTree,
+      depth: 0,
+      closedFolders: [FOLDER1],
+      state,
+      renderVars,
+    })
 
     expect(result).to.be.a('string')
 
@@ -110,7 +116,7 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    const result = tree(emptyRootTree, 0, [], state, renderVars)
+    const result = tree({ branch: emptyRootTree, depth: 0, closedFolders: [], state, renderVars })
 
     expect(result).to.be.a('string')
 
@@ -125,7 +131,7 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    tree(closedSubTree, 0, [FOLDER1], state, renderVars)
+    tree({ branch: closedSubTree, depth: 0, closedFolders: [FOLDER1], state, renderVars })
 
     sinon.assert.notCalled(sortSpy)
   })
@@ -135,7 +141,13 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    tree(mockRootFolders.rootFolders[0]?.fileTree!, 0, [], state, renderVars)
+    tree({
+      branch: mockRootFolders.rootFolders[0]?.fileTree!,
+      depth: 0,
+      closedFolders: [],
+      state,
+      renderVars,
+    })
 
     sinon.assert.callCount(itemSpy, getMockFileList().length)
     // Order like this due to child sorting


### PR DESCRIPTION
Closes #153 

# Summary of Changes

- Updated check for isClosed
- Stopped folders being closeable during search
- Updated tests
- Moved args on tree() to an object
