### PR TITLE
feat(190): remove refresh from root folder if refreshing

### DIFF
--- a/src/templates/workspace/snippets/externalWorkspace.ts
+++ b/src/templates/workspace/snippets/externalWorkspace.ts
@@ -46,6 +46,7 @@ export const externalWorkspace = (state: WorkspaceState, renderVars: RenderVars)
               isClosable: false,
               isClosed: false,
               renderVars,
+              result: 'ok',
               state,
             })}
             ${itemFile({ depth: 0, file, state, renderVars })}

--- a/src/templates/workspace/snippets/itemFolder.ts
+++ b/src/templates/workspace/snippets/itemFolder.ts
@@ -2,6 +2,7 @@ import * as os from 'os'
 import { cleanLabel } from '../../../utils/string/cleanLabel'
 import {
   FileTree,
+  FindFileResult,
   WorkspaceState,
 } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { RenderVars } from '../../../webviews/webviews.interface'
@@ -17,6 +18,7 @@ export type ItemFolderProps = {
   isClosed: boolean
   isFolderError?: boolean
   renderVars: RenderVars
+  result: FindFileResult
   state: WorkspaceState
 }
 
@@ -27,6 +29,7 @@ export const itemFolder = ({
   isClosed,
   isFolderError = false,
   renderVars,
+  result,
   state,
 }: ItemFolderProps): string => {
   const homeDir = os.homedir()
@@ -58,7 +61,7 @@ export const itemFolder = ({
     },
   ]
 
-  if (isRoot) {
+  if (isRoot && result !== 'loading') {
     buttons.unshift({
       codicon: 'refresh',
       file: folderPathShort,

--- a/src/templates/workspace/snippets/listContent.ts
+++ b/src/templates/workspace/snippets/listContent.ts
@@ -42,6 +42,7 @@ export const listContent = ({
     },
     isClosed,
     renderVars,
+    result,
     state,
   }
 
@@ -71,6 +72,7 @@ export const listContent = ({
       depth: 0,
       renderVars,
       state,
+      result,
     })
   }
 

--- a/src/templates/workspace/snippets/tree.ts
+++ b/src/templates/workspace/snippets/tree.ts
@@ -1,6 +1,7 @@
 import { RenderVars } from '../../../webviews/webviews.interface'
 import {
   FileTree,
+  FindFileResult,
   WorkspaceState,
 } from '../../../webviews/Workspace/WorkspaceViewProvider.interface'
 import { isFile } from '../../helpers/isFile'
@@ -13,10 +14,18 @@ export type TreeProps = {
   closedFolders: string[]
   depth: number
   renderVars: RenderVars
+  result: FindFileResult
   state: WorkspaceState
 }
 
-export const tree = ({ branch, closedFolders, depth, renderVars, state }: TreeProps): string => {
+export const tree = ({
+  branch,
+  closedFolders,
+  depth,
+  renderVars,
+  result,
+  state,
+}: TreeProps): string => {
   const { files, folderPathSegment, isRoot, sub } = branch
   const isClosed = !state.search.term && closedFolders.includes(folderPathSegment)
 
@@ -33,13 +42,13 @@ export const tree = ({ branch, closedFolders, depth, renderVars, state }: TreePr
   }
 
   return `
-    ${itemFolder({ folder: branch, depth, isClosed, state, renderVars })}
+    ${itemFolder({ folder: branch, depth, isClosed, state, result, renderVars })}
     ${children
       .map((child) => {
         if (isFile(child)) {
           return itemFile({ depth: fileDepth, file: child, renderVars, state })
         } else {
-          return tree({ branch: child, depth: treeDepth, closedFolders, state, renderVars })
+          return tree({ branch: child, depth: treeDepth, closedFolders, state, result, renderVars })
         }
       })
       .join('')}

--- a/src/test/suite/templates/workspace/snippets/itemFolder.test.ts
+++ b/src/test/suite/templates/workspace/snippets/itemFolder.test.ts
@@ -82,6 +82,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
       folder,
       isClosed: false,
       renderVars: mockRenderVars,
+      result: 'ok',
       state: mockState,
     })
 
@@ -107,6 +108,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
       isClosed: false,
       isFolderError: true,
       renderVars: mockRenderVars,
+      result: 'nonexistent',
       state: mockState,
     })
 
@@ -135,6 +137,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
       folder: { ...folder, isRoot: true },
       isClosed: false,
       renderVars: { ...mockRenderVars, cleanLabels: true },
+      result: 'ok',
       state: mockState,
     })
 
@@ -163,6 +166,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
       folder: { ...folder, isRoot: true },
       isClosed: false,
       renderVars: testMockRenderVars,
+      result: 'ok',
       state: mockState,
     })
 
@@ -191,6 +195,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
       folder: { ...folder, isRoot: true },
       isClosed: false,
       renderVars: mockRenderVars,
+      result: 'ok',
       state: mockState,
     })
 
@@ -207,6 +212,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         folder,
         isClosed: true,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -223,6 +229,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         folder,
         isClosed: true,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -241,6 +248,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         isClosable: true,
         isClosed: true,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -257,6 +265,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         isClosable: true,
         isClosed: false,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -273,6 +282,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         isClosable: false,
         isClosed: false,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -287,6 +297,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         folder,
         isClosed: false,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -304,6 +315,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         folder,
         isClosed: true,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: {
           ...mockState,
           selected: path.join(folder.folderPath, 'Impala.code-workspace'),
@@ -324,6 +336,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         folder: { ...folder, compactedFolders: [] },
         isClosed: false,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 
@@ -340,6 +353,7 @@ suite('Templates > Workspace > Snippets: itemFolder()', () => {
         },
         isClosed: false,
         renderVars: mockRenderVars,
+        result: 'ok',
         state: mockState,
       })
 

--- a/src/test/suite/templates/workspace/snippets/tree.test.ts
+++ b/src/test/suite/templates/workspace/snippets/tree.test.ts
@@ -79,7 +79,14 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    const result = tree({ branch: emptySubTree, depth: 0, closedFolders: [], state, renderVars })
+    const result = tree({
+      branch: emptySubTree,
+      closedFolders: [],
+      depth: 0,
+      renderVars,
+      result: 'ok',
+      state,
+    })
 
     expect(result).to.be.a('string')
     expect(result).to.be.empty
@@ -97,10 +104,11 @@ suite('Templates > Workspace > Snippets: tree()', () => {
 
     const result = tree({
       branch: closedSubTree,
-      depth: 0,
       closedFolders: [FOLDER1],
-      state,
+      depth: 0,
       renderVars,
+      result: 'no-workspaces',
+      state,
     })
 
     expect(result).to.be.a('string')
@@ -116,7 +124,14 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    const result = tree({ branch: emptyRootTree, depth: 0, closedFolders: [], state, renderVars })
+    const result = tree({
+      branch: emptyRootTree,
+      closedFolders: [],
+      depth: 0,
+      renderVars,
+      result: 'no-workspaces',
+      state,
+    })
 
     expect(result).to.be.a('string')
 
@@ -131,7 +146,14 @@ suite('Templates > Workspace > Snippets: tree()', () => {
     const state = getMockState({ ...mockRootFolders })
     const renderVars = getMockRenderVars()
 
-    tree({ branch: closedSubTree, depth: 0, closedFolders: [FOLDER1], state, renderVars })
+    tree({
+      branch: closedSubTree,
+      closedFolders: [FOLDER1],
+      depth: 0,
+      renderVars,
+      result: 'ok',
+      state,
+    })
 
     sinon.assert.notCalled(sortSpy)
   })
@@ -143,10 +165,11 @@ suite('Templates > Workspace > Snippets: tree()', () => {
 
     tree({
       branch: mockRootFolders.rootFolders[0]?.fileTree!,
-      depth: 0,
       closedFolders: [],
-      state,
+      depth: 0,
       renderVars,
+      result: 'ok',
+      state,
     })
 
     sinon.assert.callCount(itemSpy, getMockFileList().length)


### PR DESCRIPTION
Closes #190 

# Summary of Changes

- Hide root folder refresh icon if root folder is loading