### PR TITLE
fix(195): add folder buttons back to root folders with error

### DIFF
--- a/src/templates/workspace/snippets/itemFolder.ts
+++ b/src/templates/workspace/snippets/itemFolder.ts
@@ -90,7 +90,7 @@ export const itemFolder = ({
         <span class="list__text">
           <span class="list__title">${visibleLabel}</span>
         </span>
-        ${isFolderError ? '' : itemButtons(folderButtons)}
+        ${itemButtons(folderButtons)}
       </span>
     </li>
   `


### PR DESCRIPTION
Closes #195 

# Summary of Changes

- Always render root folder buttons
